### PR TITLE
feat(core): add interactive action button support for DataGrid columns

### DIFF
--- a/samples/SampleApp.Maui/AppShell.xaml
+++ b/samples/SampleApp.Maui/AppShell.xaml
@@ -30,6 +30,12 @@
             Icon="icon_theme.png"
             ContentTemplate="{DataTemplate local:ThemingPage}"
             Route="ThemingPage" />
+
+        <ShellContent
+            Title="MVVM Actions"
+            Icon="icon_actions.png"
+            ContentTemplate="{DataTemplate local:MvvmActionsPage}"
+            Route="MvvmActionsPage" />
     </TabBar>
 
 </Shell>

--- a/samples/SampleApp.Maui/EmployeeDetailsPage.xaml
+++ b/samples/SampleApp.Maui/EmployeeDetailsPage.xaml
@@ -1,0 +1,164 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="SampleApp.Maui.EmployeeDetailsPage"
+             Title="Employee Details"
+             BackgroundColor="#F8F9FA">
+
+    <ScrollView>
+        <VerticalStackLayout Padding="24,24" Spacing="0">
+
+            <!-- Avatar + name header -->
+            <VerticalStackLayout HorizontalOptions="Center" Spacing="8" Margin="0,0,0,24">
+                <Border x:Name="avatarBorder"
+                        WidthRequest="80" HeightRequest="80"
+                        StrokeShape="RoundRectangle 40"
+                        Stroke="Transparent"
+                        BackgroundColor="#0D6EFD"
+                        HorizontalOptions="Center">
+                    <Label x:Name="initialsLabel"
+                           FontSize="28"
+                           FontAttributes="Bold"
+                           TextColor="White"
+                           HorizontalOptions="Center"
+                           VerticalOptions="Center"
+                           HorizontalTextAlignment="Center"
+                           VerticalTextAlignment="Center" />
+                </Border>
+
+                <Label x:Name="nameLabel"
+                       FontSize="22"
+                       FontAttributes="Bold"
+                       HorizontalOptions="Center"
+                       HorizontalTextAlignment="Center" />
+
+                <Label x:Name="subtitleLabel"
+                       FontSize="14"
+                       TextColor="#6C757D"
+                       HorizontalOptions="Center"
+                       HorizontalTextAlignment="Center" />
+            </VerticalStackLayout>
+
+            <!-- Details card -->
+            <Border StrokeShape="RoundRectangle 12"
+                    Stroke="#DEE2E6"
+                    BackgroundColor="White"
+                    Padding="20,16"
+                    Margin="0,0,0,16">
+                <VerticalStackLayout Spacing="12">
+                    <Label Text="Employee Details"
+                           FontAttributes="Bold"
+                           FontSize="15"
+                           Margin="0,0,0,4" />
+
+                    <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto"
+                          ColumnDefinitions="110,*"
+                          RowSpacing="10"
+                          ColumnSpacing="16">
+
+                        <Label Grid.Row="0" Grid.Column="0"
+                               Text="Employee ID"
+                               TextColor="#6C757D"
+                               FontSize="13" />
+                        <Label x:Name="idLabel"
+                               Grid.Row="0" Grid.Column="1"
+                               FontAttributes="Bold"
+                               FontSize="13" />
+
+                        <Label Grid.Row="1" Grid.Column="0"
+                               Text="Department"
+                               TextColor="#6C757D"
+                               FontSize="13" />
+                        <Label x:Name="deptLabel"
+                               Grid.Row="1" Grid.Column="1"
+                               FontAttributes="Bold"
+                               FontSize="13" />
+
+                        <Label Grid.Row="2" Grid.Column="0"
+                               Text="Level"
+                               TextColor="#6C757D"
+                               FontSize="13" />
+                        <Label x:Name="levelLabel"
+                               Grid.Row="2" Grid.Column="1"
+                               FontAttributes="Bold"
+                               FontSize="13" />
+
+                        <Label Grid.Row="3" Grid.Column="0"
+                               Text="Salary"
+                               TextColor="#6C757D"
+                               FontSize="13" />
+                        <Label x:Name="salaryLabel"
+                               Grid.Row="3" Grid.Column="1"
+                               FontAttributes="Bold"
+                               FontSize="13" />
+
+                        <Label Grid.Row="4" Grid.Column="0"
+                               Text="Hire Date"
+                               TextColor="#6C757D"
+                               FontSize="13" />
+                        <Label x:Name="hireDateLabel"
+                               Grid.Row="4" Grid.Column="1"
+                               FontAttributes="Bold"
+                               FontSize="13" />
+
+                        <Label Grid.Row="5" Grid.Column="0"
+                               Text="Status"
+                               TextColor="#6C757D"
+                               FontSize="13" />
+                        <Label x:Name="statusLabel"
+                               Grid.Row="5" Grid.Column="1"
+                               FontAttributes="Bold"
+                               FontSize="13" />
+                    </Grid>
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Performance card -->
+            <Border StrokeShape="RoundRectangle 12"
+                    Stroke="#DEE2E6"
+                    BackgroundColor="White"
+                    Padding="20,16"
+                    Margin="0,0,0,28">
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Performance"
+                           FontAttributes="Bold"
+                           FontSize="15"
+                           Margin="0,0,0,2" />
+
+                    <Grid ColumnDefinitions="110,*" ColumnSpacing="16">
+                        <Label Grid.Column="0"
+                               Text="Score"
+                               TextColor="#6C757D"
+                               FontSize="13" />
+                        <Label x:Name="perfLabel"
+                               Grid.Column="1"
+                               FontAttributes="Bold"
+                               FontSize="13" />
+                    </Grid>
+
+                    <Grid ColumnDefinitions="110,*" ColumnSpacing="16">
+                        <Label Grid.Column="0"
+                               Text="Rating"
+                               TextColor="#6C757D"
+                               FontSize="13" />
+                        <Label x:Name="ratingLabel"
+                               Grid.Column="1"
+                               FontAttributes="Bold"
+                               FontSize="13" />
+                    </Grid>
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Close button -->
+            <Button Text="Close"
+                    Clicked="OnCloseClicked"
+                    BackgroundColor="#6C757D"
+                    TextColor="White"
+                    CornerRadius="8"
+                    HeightRequest="48"
+                    HorizontalOptions="Fill" />
+
+        </VerticalStackLayout>
+    </ScrollView>
+
+</ContentPage>

--- a/samples/SampleApp.Maui/EmployeeDetailsPage.xaml.cs
+++ b/samples/SampleApp.Maui/EmployeeDetailsPage.xaml.cs
@@ -1,0 +1,50 @@
+namespace SampleApp.Maui;
+
+public partial class EmployeeDetailsPage : ContentPage
+{
+    public EmployeeDetailsPage(Employee employee)
+    {
+        InitializeComponent();
+
+        // Build initials (up to 2 characters)
+        var parts = employee.Name.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        initialsLabel.Text = parts.Length >= 2
+            ? $"{parts[0][0]}{parts[^1][0]}".ToUpperInvariant()
+            : employee.Name.Length > 0 ? employee.Name[0].ToString().ToUpperInvariant() : "?";
+
+        // Department-tinted avatar background
+        avatarBorder.BackgroundColor = employee.Department switch
+        {
+            "Engineering" => Color.FromArgb("#0D6EFD"),
+            "Marketing"   => Color.FromArgb("#6F42C1"),
+            "Finance"     => Color.FromArgb("#20C997"),
+            "HR"          => Color.FromArgb("#FD7E14"),
+            "Design"      => Color.FromArgb("#E83E8C"),
+            "Product"     => Color.FromArgb("#6610F2"),
+            "Sales"       => Color.FromArgb("#28A745"),
+            _             => Color.FromArgb("#0D6EFD")
+        };
+
+        nameLabel.Text = employee.Name;
+        subtitleLabel.Text = $"{employee.Level}  ·  {employee.Department}";
+
+        idLabel.Text = employee.Id.ToString();
+        deptLabel.Text = employee.Department;
+        levelLabel.Text = employee.Level;
+        salaryLabel.Text = employee.Salary.ToString("C0");
+        hireDateLabel.Text = employee.HireDate.ToString("MMMM d, yyyy");
+
+        statusLabel.Text = employee.IsActive ? "Active ✓" : "Inactive ✗";
+        statusLabel.TextColor = employee.IsActive
+            ? Color.FromArgb("#28A745")
+            : Color.FromArgb("#DC3545");
+
+        perfLabel.Text = $"{employee.Performance:F1} / 100";
+        ratingLabel.Text = new string('★', employee.Rating) + new string('☆', 5 - employee.Rating);
+    }
+
+    private async void OnCloseClicked(object sender, EventArgs e)
+    {
+        await Navigation.PopModalAsync();
+    }
+}

--- a/samples/SampleApp.Maui/MvvmActionsPage.xaml
+++ b/samples/SampleApp.Maui/MvvmActionsPage.xaml
@@ -1,0 +1,112 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:dg="clr-namespace:KumikoUI.Maui;assembly=KumikoUI.Maui"
+             xmlns:core="clr-namespace:KumikoUI.Core.Models;assembly=KumikoUI.Core"
+             xmlns:render="clr-namespace:KumikoUI.Core.Rendering;assembly=KumikoUI.Core"
+             x:Class="SampleApp.Maui.MvvmActionsPage"
+             Title="MVVM Row Actions">
+
+    <Grid RowDefinitions="Auto,*" Padding="0">
+        <Label Text="MVVM Row Actions — Tap Delete or Details on any row"
+               FontSize="18"
+               FontAttributes="Bold"
+               Padding="16,12"
+               Grid.Row="0" />
+
+        <!--
+            x:Name="actionsGrid" is referenced below by the command bindings.
+            actionsGrid.BindingContext = MvvmActionsViewModel (set in code-behind).
+        -->
+        <dg:DataGridView x:Name="actionsGrid"
+                         Grid.Row="1"
+                         ItemsSource="{Binding Employees}"
+                         EditTriggers="SingleTap,F2Key"
+                         RowHeight="44"
+                         HeaderHeight="40">
+            <dg:DataGridView.Columns>
+                <core:DataGridColumn Header="Id"
+                                     PropertyName="Id"
+                                     ColumnType="Numeric"
+                                     Width="52"
+                                     IsReadOnly="True"
+                                     AllowTabStop="False" />
+
+                <core:DataGridColumn Header="Name"
+                                     PropertyName="Name"
+                                     Width="160"
+                                     IsReadOnly="True" />
+
+                <core:DataGridColumn Header="Department"
+                                     PropertyName="Department"
+                                     Width="130"
+                                     IsReadOnly="True" />
+
+                <core:DataGridColumn Header="Level"
+                                     PropertyName="Level"
+                                     Width="90"
+                                     IsReadOnly="True" />
+
+                <core:DataGridColumn Header="Salary"
+                                     PropertyName="Salary"
+                                     ColumnType="Numeric"
+                                     Format="C0"
+                                     Width="110"
+                                     IsReadOnly="True"
+                                     TextAlignment="Right" />
+
+                <core:DataGridColumn Header="Active"
+                                     PropertyName="IsActive"
+                                     ColumnType="Boolean"
+                                     Width="60"
+                                     IsReadOnly="True"
+                                     AllowTabStop="False" />
+
+                <!--
+                    Actions column.
+                    PropertyName="" short-circuits DataGridSource.BuildAccessor to
+                    return item => item, so both the renderer and the editor factory
+                    receive the full Employee object as their 'value' argument.
+
+                    CustomCellRenderer is fully declared here in XAML.
+                    MauiActionButtonDefinition is a BindableObject, so Command accepts
+                    {Binding} expressions.  MauiActionButtonDefinition is NOT in the
+                    visual tree, so BindingContext is NOT inherited automatically —
+                    use Source={x:Reference actionsGrid} to resolve the ViewModel.
+
+                    The editor factory (in code-behind) reuses this same Buttons list,
+                    so commands are already bound when a row is tapped.
+                -->
+                <core:DataGridColumn x:Name="actionsColumn"
+                                     Header="Actions"
+                                     PropertyName=""
+                                     ColumnType="Template"
+                                     Width="200"
+                                     IsReadOnly="False"
+                                     AllowSorting="False"
+                                     AllowFiltering="False"
+                                     AllowTabStop="False"
+                                     SizeMode="Star"
+                                     StarWeight="1">
+                    <core:DataGridColumn.CustomCellRenderer>
+                        <render:ActionButtonsCellRenderer>
+                            <render:ActionButtonsCellRenderer.Buttons>
+                                <dg:MauiActionButtonDefinition
+                                    Label="Details"
+                                    BackgroundColor="13,110,253"
+                                    Command="{Binding Path=BindingContext.ViewDetailsCommand,
+                                                      Source={x:Reference actionsGrid}}" />
+                                <dg:MauiActionButtonDefinition
+                                    Label="Delete"
+                                    BackgroundColor="220,53,69"
+                                    Command="{Binding Path=BindingContext.DeleteCommand,
+                                                      Source={x:Reference actionsGrid}}" />
+                            </render:ActionButtonsCellRenderer.Buttons>
+                        </render:ActionButtonsCellRenderer>
+                    </core:DataGridColumn.CustomCellRenderer>
+                </core:DataGridColumn>
+            </dg:DataGridView.Columns>
+        </dg:DataGridView>
+    </Grid>
+
+</ContentPage>

--- a/samples/SampleApp.Maui/MvvmActionsPage.xaml.cs
+++ b/samples/SampleApp.Maui/MvvmActionsPage.xaml.cs
@@ -1,0 +1,120 @@
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+
+namespace SampleApp.Maui;
+
+public partial class MvvmActionsPage : ContentPage
+{
+    private readonly MvvmActionsViewModel _viewModel;
+
+    public MvvmActionsPage()
+    {
+        InitializeComponent();
+
+        _viewModel = new MvvmActionsViewModel();
+        _viewModel.DeleteRequested += OnDeleteRequested;
+        _viewModel.ViewDetailsRequested += OnViewDetailsRequested;
+
+        BindingContext = _viewModel;
+        _viewModel.LoadData();
+    }
+
+    private async void OnDeleteRequested(object? sender, Employee employee)
+    {
+        bool confirmed = await DisplayAlert(
+            "Delete Employee",
+            $"Are you sure you want to delete {employee.Name}?",
+            "Delete",
+            "Cancel");
+
+        if (confirmed)
+            _viewModel.Employees.Remove(employee);
+    }
+
+    private async void OnViewDetailsRequested(object? sender, Employee employee)
+    {
+        await Navigation.PushModalAsync(new EmployeeDetailsPage(employee));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ViewModel
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// ViewModel for the MVVM actions demo. Exposes employee data and two commands
+/// that raise events — the View (page code-behind) handles UI concerns such as
+/// showing confirmation dialogs and pushing modal pages.
+/// </summary>
+public class MvvmActionsViewModel
+{
+    /// <summary>The collection bound to the DataGridView.</summary>
+    public ObservableCollection<Employee> Employees { get; } = new();
+
+    /// <summary>Raised to request confirmation and removal of an employee.</summary>
+    public event EventHandler<Employee>? DeleteRequested;
+
+    /// <summary>Raised to request navigation to the employee details overlay.</summary>
+    public event EventHandler<Employee>? ViewDetailsRequested;
+
+    /// <summary>Fires <see cref="DeleteRequested"/> with the target employee.</summary>
+    public ICommand DeleteCommand => new Command<Employee>(e =>
+        DeleteRequested?.Invoke(this, e));
+
+    /// <summary>Fires <see cref="ViewDetailsRequested"/> with the target employee.</summary>
+    public ICommand ViewDetailsCommand => new Command<Employee>(e =>
+        ViewDetailsRequested?.Invoke(this, e));
+
+    /// <summary>Populates <see cref="Employees"/> with deterministic sample data.</summary>
+    public void LoadData()
+    {
+        var departments = new[] { "Engineering", "Marketing", "Finance", "HR", "Design", "Product", "Sales" };
+        var levels = new[] { "Junior", "Mid", "Senior", "Lead", "Principal" };
+        var firstNames = new[]
+        {
+            "Alice", "Bob", "Carol", "David", "Eva", "Frank", "Grace", "Henry",
+            "Iris", "Jack", "Karen", "Leo", "Mia", "Ned", "Olivia", "Paul",
+            "Quinn", "Rosa", "Sam", "Tina", "Uma", "Victor", "Wendy", "Xander",
+            "Yasmin", "Zack", "Amy", "Brian"
+        };
+        var lastNames = new[]
+        {
+            "Anderson", "Brown", "Chen", "Davis", "Evans", "Foster", "Green",
+            "Harris", "Ito", "Jones", "Kim", "Lee", "Martinez", "Nguyen",
+            "O'Brien", "Patel", "Quinn", "Rivera", "Smith", "Taylor"
+        };
+
+        var rng = new Random(42);
+
+        for (int i = 1; i <= 28; i++)
+        {
+            string firstName = firstNames[(i - 1) % firstNames.Length];
+            string lastName = lastNames[(i - 1) % lastNames.Length];
+            string level = levels[rng.Next(levels.Length)];
+            string dept = departments[rng.Next(departments.Length)];
+
+            decimal baseSalary = level switch
+            {
+                "Junior" => 60_000,
+                "Mid" => 90_000,
+                "Senior" => 130_000,
+                "Lead" => 165_000,
+                _ => 200_000
+            };
+
+            Employees.Add(new Employee
+            {
+                Id = i,
+                Name = $"{firstName} {lastName}",
+                Department = dept,
+                Level = level,
+                Salary = baseSalary + rng.Next(-10_000, 20_000),
+                HireDate = DateTime.Today.AddDays(-rng.Next(180, 3650)),
+                IsActive = rng.NextDouble() > 0.15,
+                City = "New York",
+                Performance = Math.Round(rng.NextDouble() * 100, 1),
+                Rating = rng.Next(1, 6)
+            });
+        }
+    }
+}

--- a/samples/SampleApp.Maui/Resources/Images/icon_actions.svg
+++ b/samples/SampleApp.Maui/Resources/Images/icon_actions.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <!-- cursor arrow -->
+  <polygon points="80,80 80,380 180,300 220,420 280,400 240,280 360,280" 
+           fill="black" />
+  <!-- small squares representing buttons -->
+  <rect x="300" y="100" width="150" height="55" rx="10" fill="black" opacity="0.7"/>
+  <rect x="300" y="175" width="150" height="55" rx="10" fill="black" opacity="0.5"/>
+</svg>

--- a/src/KumikoUI.Core/Components/DrawnActionButtons.cs
+++ b/src/KumikoUI.Core/Components/DrawnActionButtons.cs
@@ -1,0 +1,143 @@
+using KumikoUI.Core.Input;
+using KumikoUI.Core.Models;
+using KumikoUI.Core.Rendering;
+
+namespace KumikoUI.Core.Components;
+
+/// <summary>
+/// A canvas-drawn component that renders an arbitrary set of action buttons
+/// inside a grid cell. Add any number of <see cref="ActionButtonDefinition"/>
+/// entries to <see cref="Buttons"/> — they are distributed with equal widths
+/// across the cell.
+/// </summary>
+/// <remarks>
+/// Pair with <see cref="ActionButtonsCellRenderer"/> for the always-visible
+/// display pass. The editor activates on the first tap (set column
+/// <c>EditTrigger = SingleTap</c>) and closes automatically after any
+/// button action fires.
+///
+/// <b>Code-behind usage</b> — capture the row item and wire <c>Command</c> per button:
+/// <code>
+/// actionsColumn.CustomEditorFactory = (value, bounds) => new DrawnActionButtons
+/// {
+///     Bounds  = bounds,
+///     RowItem = value,
+///     Buttons =
+///     [
+///         new() { Label = "Edit",   BackgroundColor = new GridColor(13, 110, 253), Command = vm.EditCommand   },
+///         new() { Label = "Delete", BackgroundColor = new GridColor(220, 53, 69),  Command = vm.DeleteCommand }
+///     ]
+/// };
+/// </code>
+/// When <see cref="ActionButtonDefinition.CommandParameter"/> is not set the
+/// row item (<see cref="RowItem"/>) is passed to <c>ICommand.Execute</c>.
+/// </remarks>
+public class DrawnActionButtons : DrawnComponent
+{
+    private int _pressedIndex = -1;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// <c>true</c> — the grid forwards the activating tap to this editor immediately
+    /// after creation so the button fires on the first touch.
+    /// </remarks>
+    public override bool ActivatesImmediately => true;
+
+    /// <summary>
+    /// The ordered list of buttons to render.
+    /// Buttons are distributed with equal widths across the cell.
+    /// </summary>
+    public IList<IActionButtonDefinition> Buttons { get; set; } = new List<IActionButtonDefinition>();
+
+    /// <summary>
+    /// The row item (the cell value for a <c>PropertyName=""</c> column).
+    /// Used as the default <c>CommandParameter</c> for any button whose
+    /// <see cref="ActionButtonDefinition.CommandParameter"/> is <see langword="null"/>.
+    /// </summary>
+    public object? RowItem { get; set; }
+
+    /// <summary>Corner radius for all button pills.</summary>
+    public float CornerRadius { get; set; } = 5f;
+
+    /// <summary>Horizontal gap between adjacent buttons (pixels).</summary>
+    public float ButtonSpacing { get; set; } = 6f;
+
+    /// <summary>Inset from all four cell edges (pixels).</summary>
+    public float CellPadding { get; set; } = 4f;
+
+    /// <inheritdoc />
+    public override void OnDraw(IDrawingContext ctx)
+    {
+        if (Buttons.Count == 0) return;
+        var rects = ActionButtonLayout.ComputeButtonRects(Bounds, Buttons.Count, CellPadding, ButtonSpacing);
+        for (int i = 0; i < Buttons.Count; i++)
+            DrawButton(ctx, rects[i], Buttons[i], pressed: i == _pressedIndex);
+    }
+
+    /// <inheritdoc />
+    public override bool OnPointerDown(GridPointerEventArgs e)
+    {
+        var rects = ActionButtonLayout.ComputeButtonRects(Bounds, Buttons.Count, CellPadding, ButtonSpacing);
+        for (int i = 0; i < rects.Count; i++)
+        {
+            if (rects[i].Contains(e.X, e.Y))
+            {
+                _pressedIndex = i;
+                InvalidateVisual();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <inheritdoc />
+    public override bool OnPointerUp(GridPointerEventArgs e)
+    {
+        int wasPressed = _pressedIndex;
+        _pressedIndex = -1;
+        InvalidateVisual();
+
+        if (wasPressed < 0 || wasPressed >= Buttons.Count) return false;
+
+        var rects = ActionButtonLayout.ComputeButtonRects(Bounds, Buttons.Count, CellPadding, ButtonSpacing);
+        if (rects[wasPressed].Contains(e.X, e.Y))
+        {
+            var btn = Buttons[wasPressed];
+            var param = btn.CommandParameter ?? RowItem;
+            btn.Command?.Execute(param);
+            btn.Action?.Invoke();
+            RaiseEditCompleted();
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Called by <c>CellEditorFactory.ApplyThemeToEditor</c> to adapt button
+    /// colors to the active grid theme. Override to customize.
+    /// </summary>
+    public virtual void ApplyTheme(DataGridStyle style) { }
+
+    // ── Drawing ──────────────────────────────────────────────────
+
+    private void DrawButton(IDrawingContext ctx, GridRect rect, IActionButtonDefinition btn, bool pressed)
+    {
+        var bg = pressed
+            ? new GridColor(
+                (byte)Math.Max(0, btn.BackgroundColor.R - 40),
+                (byte)Math.Max(0, btn.BackgroundColor.G - 40),
+                (byte)Math.Max(0, btn.BackgroundColor.B - 40),
+                btn.BackgroundColor.A)
+            : btn.BackgroundColor;
+
+        ctx.FillRoundRect(rect, CornerRadius, new GridPaint { Color = bg, IsAntiAlias = true });
+        ctx.DrawTextInRect(btn.Label, rect, new GridPaint
+        {
+            Color = btn.TextColor,
+            Font = new GridFont("Default", 11, bold: true),
+            IsAntiAlias = true
+        }, GridTextAlignment.Center, GridVerticalAlignment.Center);
+    }
+}
+

--- a/src/KumikoUI.Core/Components/DrawnComponent.cs
+++ b/src/KumikoUI.Core/Components/DrawnComponent.cs
@@ -82,6 +82,15 @@ public abstract class DrawnComponent
     /// <summary>Draw this component. Override in derived classes.</summary>
     public abstract void OnDraw(IDrawingContext ctx);
 
+    /// <summary>
+    /// When <see langword="true"/>, the grid immediately forwards the activating tap
+    /// to the editor as a synthetic press + release after <c>BeginEdit</c> is called.
+    /// This allows editors like <c>DrawnActionButtons</c> to respond on the very
+    /// first tap rather than requiring a second tap to interact.
+    /// Default: <see langword="false"/>.
+    /// </summary>
+    public virtual bool ActivatesImmediately => false;
+
     /// <summary>Request a redraw of the hosting surface.</summary>
     public void InvalidateVisual() => RedrawRequested?.Invoke();
 

--- a/src/KumikoUI.Core/Editing/CellEditorFactory.cs
+++ b/src/KumikoUI.Core/Editing/CellEditorFactory.cs
@@ -61,6 +61,7 @@ public static class CellEditorFactory
             case DrawnNumericUpDown numeric: numeric.ApplyTheme(style); break;
             case DrawnDatePicker datePicker: datePicker.ApplyTheme(style); break;
             case DrawnScrollPicker picker: picker.ApplyTheme(style); break;
+            case DrawnActionButtons actionButtons: actionButtons.ApplyTheme(style); break;
         }
     }
 
@@ -211,12 +212,15 @@ public static class CellEditorFactory
     private static DrawnComponent? CreateTemplateEditor(
         DataGridColumn column, object? value, GridRect cellBounds)
     {
-        // Template columns: prefer CustomEditorFactory, then EditorDescriptor, then text fallback
+        // Priority: explicit factory → EditorDescriptor → renderer self-creates → text fallback
         if (column.CustomEditorFactory != null)
             return column.CustomEditorFactory(value, cellBounds);
 
         if (column.EditorDescriptor != null)
             return column.EditorDescriptor.CreateEditor(value, cellBounds);
+
+        if (column.CustomCellRenderer is ICellEditorProvider editorProvider)
+            return editorProvider.CreateEditor(value, cellBounds);
 
         // Fallback to text editor
         return CreateTextEditor(column, value, cellBounds, null, EditTextSelectionMode.SelectAll);

--- a/src/KumikoUI.Core/Editing/EditSession.cs
+++ b/src/KumikoUI.Core/Editing/EditSession.cs
@@ -455,6 +455,38 @@ public class EditSession
         return false;
     }
 
+    /// <summary>
+    /// Immediately forwards the activating tap to an editor that has
+    /// <see cref="DrawnComponent.ActivatesImmediately"/> set to <c>true</c>
+    /// (e.g. <c>DrawnActionButtons</c>).
+    /// Synthesizes a <c>Pressed</c> event at the same coordinates and then
+    /// dispatches the original <c>Released</c> event so the editor sees a
+    /// complete press–release cycle without requiring a second tap.
+    /// Does nothing if the session is not currently editing or the active
+    /// editor does not have <c>ActivatesImmediately == true</c>.
+    /// </summary>
+    /// <param name="releasedEvent">
+    /// The original <c>Released</c> pointer event that triggered <c>BeginEdit</c>.
+    /// </param>
+    public void TryForwardInitialTap(GridPointerEventArgs releasedEvent)
+    {
+        if (!_isEditing || _activeEditor == null) return;
+        if (!_activeEditor.ActivatesImmediately) return;
+        if (!_activeEditor.HitTest(releasedEvent.X, releasedEvent.Y)) return;
+
+        var syntheticDown = new GridPointerEventArgs
+        {
+            X = releasedEvent.X,
+            Y = releasedEvent.Y,
+            Action = InputAction.Pressed,
+            Button = releasedEvent.Button,
+            Modifiers = releasedEvent.Modifiers
+        };
+
+        _focusManager.DispatchPointer(syntheticDown);
+        _focusManager.DispatchPointer(releasedEvent);
+    }
+
     // ── Validation ──────────────────────────────────────────────
 
     private CellValidationResult? ValidateValue(int row, int col, object? value, DataGridSource dataSource)

--- a/src/KumikoUI.Core/Input/GridInputController.cs
+++ b/src/KumikoUI.Core/Input/GridInputController.cs
@@ -795,7 +795,7 @@ public class GridInputController
                 else if (_editSession != null &&
                     (_editSession.EditTriggers & EditTrigger.SingleTap) != 0)
                 {
-                    TryBeginEdit(selection, dataSource, scroll, style, null);
+                    TryBeginEdit(selection, dataSource, scroll, style, null, e);
                 }
             }
 
@@ -1201,7 +1201,8 @@ public class GridInputController
     /// </summary>
     private void TryBeginEdit(
         SelectionModel selection, DataGridSource dataSource,
-        ScrollState scroll, DataGridStyle style, char? initialCharacter)
+        ScrollState scroll, DataGridStyle style, char? initialCharacter,
+        GridPointerEventArgs? triggeringTap = null)
     {
         if (_editSession == null || !selection.CurrentCell.IsValid) return;
 
@@ -1224,6 +1225,16 @@ public class GridInputController
         if (_editSession.BeginEdit(row, col, column, dataSource, cellBounds, initialCharacter))
         {
             selection.IsEditing = true;
+
+            // For editors that activate immediately (e.g. DrawnActionButtons), forward
+            // the triggering tap so the button fires on the very first touch.
+            if (triggeringTap != null)
+            {
+                _editSession.TryForwardInitialTap(triggeringTap);
+                // Sync selection state in case the editor committed itself (e.g. button fired)
+                selection.IsEditing = _editSession.IsEditing;
+            }
+
             Redraw();
         }
     }

--- a/src/KumikoUI.Core/Models/DataGridSource.cs
+++ b/src/KumikoUI.Core/Models/DataGridSource.cs
@@ -1573,6 +1573,11 @@ public class DataGridSource
     /// </summary>
     private static Func<object, object?> BuildAccessor(Type type, string propertyPath)
     {
+        // Empty path: return the item itself. Useful for Template/action columns
+        // that need the whole row object as the cell value (e.g. CustomEditorFactory).
+        if (string.IsNullOrEmpty(propertyPath))
+            return item => item;
+
         var param = Expression.Parameter(typeof(object), "item");
         Expression body = Expression.Convert(param, type);
 

--- a/src/KumikoUI.Core/Rendering/ActionButtonDefinition.cs
+++ b/src/KumikoUI.Core/Rendering/ActionButtonDefinition.cs
@@ -1,0 +1,64 @@
+using System.Windows.Input;
+
+namespace KumikoUI.Core.Rendering;
+
+/// <summary>
+/// Defines a single action button rendered inside a grid cell.
+/// Used by <see cref="ActionButtonsCellRenderer"/> (display) and
+/// <see cref="KumikoUI.Core.Components.DrawnActionButtons"/> (interactive editor).
+/// </summary>
+/// <remarks>
+/// Any number of buttons can be added. They are distributed with equal widths
+/// across the available cell area, separated by <c>ButtonSpacing</c> and inset
+/// by <c>CellPadding</c>.
+///
+/// <b>Code-behind usage</b> (capture per-row item in a lambda):
+/// <code>
+/// new ActionButtonDefinition
+/// {
+///     Label           = "Archive",
+///     BackgroundColor = new GridColor(108, 117, 125),
+///     Action          = () => vm.ArchiveCommand.Execute(item)
+/// }
+/// </code>
+///
+/// <b>XAML-friendly usage</b> (bind a command; the row item is passed as the
+/// parameter when <see cref="CommandParameter"/> is not explicitly set):
+/// <code>
+/// &lt;render:ActionButtonDefinition Label="Archive"
+///                                BackgroundColor="108,117,125"
+///                                Command="{Binding ArchiveCommand}" /&gt;
+/// </code>
+/// </remarks>
+public class ActionButtonDefinition : IActionButtonDefinition
+{
+    /// <summary>Text displayed on the button.</summary>
+    public string Label { get; set; } = string.Empty;
+
+    /// <summary>Button background color.</summary>
+    public GridColor BackgroundColor { get; set; } = new GridColor(13, 110, 253);
+
+    /// <summary>Button label text color.</summary>
+    public GridColor TextColor { get; set; } = GridColor.White;
+
+    /// <summary>
+    /// Action invoked when this button is tapped in the interactive editor.
+    /// Ignored by the display-only <see cref="ActionButtonsCellRenderer"/>.
+    /// </summary>
+    public Action? Action { get; set; }
+
+    /// <summary>
+    /// Command executed when this button is tapped (XAML data-binding friendly).
+    /// When set, executed in addition to <see cref="Action"/> (if any).
+    /// The parameter passed to <see cref="ICommand.Execute"/> is
+    /// <see cref="CommandParameter"/> if set, otherwise the row item supplied by
+    /// <see cref="KumikoUI.Core.Components.DrawnActionButtons.RowItem"/>.
+    /// </summary>
+    public ICommand? Command { get; set; }
+
+    /// <summary>
+    /// Explicit parameter passed to <see cref="Command"/>. When <see langword="null"/>,
+    /// <see cref="KumikoUI.Core.Components.DrawnActionButtons.RowItem"/> is used instead.
+    /// </summary>
+    public object? CommandParameter { get; set; }
+}

--- a/src/KumikoUI.Core/Rendering/Color.cs
+++ b/src/KumikoUI.Core/Rendering/Color.cs
@@ -1,8 +1,12 @@
+using System.ComponentModel;
+using System.Globalization;
+
 namespace KumikoUI.Core.Rendering;
 
 /// <summary>
 /// Platform-independent color representation using RGBA values.
 /// </summary>
+[TypeConverter(typeof(GridColorTypeConverter))]
 public readonly struct GridColor : IEquatable<GridColor>
 {
     /// <summary>Red component (0–255).</summary>
@@ -86,4 +90,85 @@ public readonly struct GridColor : IEquatable<GridColor>
 
     /// <summary>Pack ARGB into a single uint for use as a cache key.</summary>
     public uint ToUint32() => ((uint)A << 24) | ((uint)R << 16) | ((uint)G << 8) | B;
+}
+
+/// <summary>
+/// Converts strings to <see cref="GridColor"/> values for XAML and design-time support.
+/// </summary>
+/// <remarks>
+/// Accepted formats:
+/// <list type="bullet">
+///   <item><description><c>R,G,B</c> — RGB, fully opaque. Example: <c>220,53,69</c></description></item>
+///   <item><description><c>R,G,B,A</c> — RGBA. Example: <c>220,53,69,128</c></description></item>
+///   <item><description><c>#RRGGBB</c> — hex RGB. Example: <c>#DC3545</c></description></item>
+///   <item><description><c>#AARRGGBB</c> — hex ARGB. Example: <c>#80DC3545</c></description></item>
+///   <item><description>Named colors: <c>White</c>, <c>Black</c>, <c>Red</c>, <c>Blue</c>,
+///     <c>Green</c>, <c>Gray</c>, <c>Transparent</c></description></item>
+/// </list>
+/// </remarks>
+public class GridColorTypeConverter : TypeConverter
+{
+    /// <inheritdoc />
+    public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
+        => sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+
+    /// <inheritdoc />
+    public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
+    {
+        if (value is not string s)
+            return base.ConvertFrom(context, culture, value);
+
+        s = s.Trim();
+
+        // Named colors
+        switch (s.ToLowerInvariant())
+        {
+            case "white":       return GridColor.White;
+            case "black":       return GridColor.Black;
+            case "red":         return GridColor.Red;
+            case "blue":        return GridColor.Blue;
+            case "green":       return GridColor.Green;
+            case "gray":        return GridColor.Gray;
+            case "transparent": return GridColor.Transparent;
+        }
+
+        // Hex: #RRGGBB or #AARRGGBB
+        if (s.StartsWith('#'))
+        {
+            var hex = s[1..];
+            if (hex.Length == 6)
+            {
+                byte r = Convert.ToByte(hex[0..2], 16);
+                byte g = Convert.ToByte(hex[2..4], 16);
+                byte b = Convert.ToByte(hex[4..6], 16);
+                return new GridColor(r, g, b);
+            }
+            if (hex.Length == 8)
+            {
+                byte a = Convert.ToByte(hex[0..2], 16);
+                byte r = Convert.ToByte(hex[2..4], 16);
+                byte g = Convert.ToByte(hex[4..6], 16);
+                byte b = Convert.ToByte(hex[6..8], 16);
+                return new GridColor(r, g, b, a);
+            }
+        }
+
+        // CSV: R,G,B  or  R,G,B,A
+        var parts = s.Split(',');
+        if (parts.Length is 3 or 4)
+        {
+            if (byte.TryParse(parts[0].Trim(), out byte r) &&
+                byte.TryParse(parts[1].Trim(), out byte g) &&
+                byte.TryParse(parts[2].Trim(), out byte b))
+            {
+                if (parts.Length == 4 && byte.TryParse(parts[3].Trim(), out byte a))
+                    return new GridColor(r, g, b, a);
+                return new GridColor(r, g, b);
+            }
+        }
+
+        throw new FormatException(
+            $"Cannot convert '{s}' to GridColor. " +
+            "Use R,G,B  /  R,G,B,A  /  #RRGGBB  /  #AARRGGBB  /  named color.");
+    }
 }

--- a/src/KumikoUI.Core/Rendering/IActionButtonDefinition.cs
+++ b/src/KumikoUI.Core/Rendering/IActionButtonDefinition.cs
@@ -1,0 +1,48 @@
+using System.Windows.Input;
+
+namespace KumikoUI.Core.Rendering;
+
+/// <summary>
+/// Describes a single action button rendered inside a grid cell.
+/// Implement this interface to create custom button definition types —
+/// for example a MAUI <c>BindableObject</c> subclass that supports
+/// <c>{Binding}</c> expressions on <c>Command</c>.
+/// </summary>
+/// <remarks>
+/// Both <see cref="ActionButtonsCellRenderer"/> (display pass) and
+/// <see cref="KumikoUI.Core.Components.DrawnActionButtons"/> (interactive editor)
+/// consume this interface, so any implementation works in both contexts.
+/// </remarks>
+public interface IActionButtonDefinition
+{
+    /// <summary>Text label rendered on the button.</summary>
+    string Label { get; }
+
+    /// <summary>Button pill background color.</summary>
+    GridColor BackgroundColor { get; }
+
+    /// <summary>Button label text color.</summary>
+    GridColor TextColor { get; }
+
+    /// <summary>
+    /// Optional callback invoked when the button is tapped.
+    /// Ignored by the display-only <see cref="ActionButtonsCellRenderer"/>.
+    /// </summary>
+    Action? Action { get; }
+
+    /// <summary>
+    /// Command executed when the button is tapped.
+    /// Ignored by the display-only <see cref="ActionButtonsCellRenderer"/>.
+    /// The parameter is <see cref="CommandParameter"/> if set, otherwise the row
+    /// item supplied by
+    /// <see cref="KumikoUI.Core.Components.DrawnActionButtons.RowItem"/>.
+    /// </summary>
+    ICommand? Command { get; }
+
+    /// <summary>
+    /// Explicit parameter passed to <see cref="Command"/>.
+    /// When <see langword="null"/>,
+    /// <see cref="KumikoUI.Core.Components.DrawnActionButtons.RowItem"/> is used.
+    /// </summary>
+    object? CommandParameter { get; }
+}

--- a/src/KumikoUI.Core/Rendering/ICellRenderer.cs
+++ b/src/KumikoUI.Core/Rendering/ICellRenderer.cs
@@ -1,6 +1,32 @@
 namespace KumikoUI.Core.Rendering;
 
+using KumikoUI.Core.Components;
 using KumikoUI.Core.Models;
+
+/// <summary>
+/// Optional companion to <see cref="ICellRenderer"/> that allows a renderer to
+/// also act as the cell editor factory for <see cref="DataGridColumnType.Template"/>
+/// columns.
+/// </summary>
+/// <remarks>
+/// When a <c>Template</c> column's <see cref="DataGridColumn.CustomCellRenderer"/>
+/// implements this interface <em>and</em> no explicit
+/// <see cref="DataGridColumn.CustomEditorFactory"/> or
+/// <see cref="DataGridColumn.EditorDescriptor"/> is set, the grid automatically
+/// calls <see cref="CreateEditor"/> to produce the interactive overlay editor.
+/// This lets a single object (e.g. <see cref="ActionButtonsCellRenderer"/>)
+/// handle both display and editing without any code-behind wiring.
+/// </remarks>
+public interface ICellEditorProvider
+{
+    /// <summary>
+    /// Creates the interactive editor for a cell.
+    /// </summary>
+    /// <param name="value">The cell's current value (row item for empty <c>PropertyName</c>).</param>
+    /// <param name="bounds">The cell rectangle in which the editor should be placed.</param>
+    /// <returns>A <see cref="DrawnComponent"/> editor, or <see langword="null"/> to skip editing.</returns>
+    DrawnComponent? CreateEditor(object? value, GridRect bounds);
+}
 
 /// <summary>
 /// Interface for rendering individual cell content.
@@ -238,5 +264,121 @@ public class ProgressBarCellRenderer : ICellRenderer
             >= 0.5 => new GridColor(255, 193, 7),
             _ => new GridColor(220, 53, 69)
         };
+    }
+}
+
+/// <summary>
+/// Renders an arbitrary set of action buttons inside a cell (display-only).
+/// Pair with <see cref="KumikoUI.Core.Components.DrawnActionButtons"/> as the
+/// interactive editor (activated on tap) to handle click events.
+/// </summary>
+/// <remarks>
+/// Both this renderer and <c>DrawnActionButtons</c> share the same
+/// <see cref="ActionButtonDefinition"/> list and layout logic, so the display
+/// and interactive states are visually identical.
+///
+/// <code>
+/// actionsColumn.CustomCellRenderer = new ActionButtonsCellRenderer
+/// {
+///     Buttons =
+///     [
+///         new() { Label = "Edit",   BackgroundColor = new GridColor(13, 110, 253) },
+///         new() { Label = "Delete", BackgroundColor = new GridColor(220, 53, 69)  }
+///     ]
+/// };
+/// </code>
+/// </remarks>
+public class ActionButtonsCellRenderer : ICellRenderer, ICellEditorProvider
+{
+    /// <summary>
+    /// The ordered list of buttons to render.
+    /// Buttons are distributed with equal widths across the cell.
+    /// Actions and commands on these definitions are ignored in display mode.
+    /// </summary>
+    public IList<IActionButtonDefinition> Buttons { get; set; } = new List<IActionButtonDefinition>();
+
+    /// <summary>Corner radius for all button pills.</summary>
+    public float CornerRadius { get; set; } = 5f;
+
+    /// <summary>Horizontal gap between adjacent buttons (pixels).</summary>
+    public float ButtonSpacing { get; set; } = 6f;
+
+    /// <summary>Inset from all four cell edges (pixels).</summary>
+    public float CellPadding { get; set; } = 4f;
+
+    /// <inheritdoc />
+    public void Render(
+        IDrawingContext ctx, GridRect cellRect, object? value,
+        string displayText, DataGridColumn column,
+        DataGridStyle style, bool isSelected,
+        CellStyle? cellStyle = null)
+    {
+        if (Buttons.Count == 0) return;
+        var rects = ActionButtonLayout.ComputeButtonRects(cellRect, Buttons.Count, CellPadding, ButtonSpacing);
+
+        for (int i = 0; i < Buttons.Count; i++)
+        {
+            var btn = Buttons[i];
+            ctx.FillRoundRect(rects[i], CornerRadius, new GridPaint { Color = btn.BackgroundColor, IsAntiAlias = true });
+            ctx.DrawTextInRect(btn.Label, rects[i], new GridPaint
+            {
+                Color = btn.TextColor,
+                Font = new GridFont("Default", 11, bold: true),
+                IsAntiAlias = true
+            }, GridTextAlignment.Center, GridVerticalAlignment.Center);
+        }
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Creates a <see cref="KumikoUI.Core.Components.DrawnActionButtons"/> editor that
+    /// shares this renderer's <see cref="Buttons"/> list. Because the list is shared,
+    /// any <c>ICommand</c> bindings already resolved on the definitions (e.g. via
+    /// <c>MauiActionButtonDefinition</c> XAML bindings) are immediately available to
+    /// the interactive editor without additional wiring.
+    /// </remarks>
+    public DrawnComponent? CreateEditor(object? value, GridRect bounds)
+        => new KumikoUI.Core.Components.DrawnActionButtons
+        {
+            Bounds  = bounds,
+            RowItem = value,
+            Buttons = Buttons,
+            CornerRadius  = CornerRadius,
+            ButtonSpacing = ButtonSpacing,
+            CellPadding   = CellPadding
+        };
+}
+
+/// <summary>
+/// Shared layout computation for action-button cells, usable by both
+/// <see cref="ActionButtonsCellRenderer"/> (display) and
+/// <see cref="KumikoUI.Core.Components.DrawnActionButtons"/> (interactive editor).
+/// </summary>
+public static class ActionButtonLayout
+{
+    /// <summary>
+    /// Computes equal-width button rects for <paramref name="count"/> buttons
+    /// within <paramref name="bounds"/>, applying <paramref name="padding"/> inset
+    /// and <paramref name="spacing"/> between buttons.
+    /// </summary>
+    public static IReadOnlyList<GridRect> ComputeButtonRects(
+        GridRect bounds, int count, float padding, float spacing)
+    {
+        var rects = new List<GridRect>(count);
+        if (count == 0 || bounds.Width <= 0 || bounds.Height <= 0)
+            return rects;
+
+        float totalSpacing = spacing * (count - 1);
+        float btnW = (bounds.Width - padding * 2 - totalSpacing) / count;
+        float btnH = bounds.Height - padding * 2;
+        float btnY = bounds.Y + padding;
+        float x = bounds.X + padding;
+
+        for (int i = 0; i < count; i++)
+        {
+            rects.Add(new GridRect(x, btnY, MathF.Max(0, btnW), MathF.Max(0, btnH)));
+            x += btnW + spacing;
+        }
+        return rects;
     }
 }

--- a/src/KumikoUI.Maui/MauiActionButtonDefinition.cs
+++ b/src/KumikoUI.Maui/MauiActionButtonDefinition.cs
@@ -1,0 +1,106 @@
+using System.Windows.Input;
+using KumikoUI.Core.Rendering;
+
+namespace KumikoUI.Maui;
+
+/// <summary>
+/// A MAUI <see cref="BindableObject"/> implementation of
+/// <see cref="IActionButtonDefinition"/> that supports full XAML data-binding
+/// on every property, including <see cref="Command"/>.
+/// </summary>
+/// <remarks>
+/// Use this type instead of <see cref="ActionButtonDefinition"/> whenever you
+/// want to bind a ViewModel <c>ICommand</c> directly in XAML:
+///
+/// <code><![CDATA[
+/// <dg:MauiActionButtonDefinition
+///     Label="Details"
+///     BackgroundColor="13,110,253"
+///     Command="{Binding Path=BindingContext.ViewDetailsCommand,
+///                       Source={x:Reference actionsGrid}}" />
+/// ]]></code>
+///
+/// Because <c>MauiActionButtonDefinition</c> is not part of the visual tree, it
+/// does <b>not</b> inherit <c>BindingContext</c> automatically. Use
+/// <c>Source={x:Reference …}</c> or <c>Source={RelativeSource …}</c> to point
+/// bindings at the correct source object.
+/// </remarks>
+public class MauiActionButtonDefinition : BindableObject, IActionButtonDefinition
+{
+    // ── BindableProperty declarations ────────────────────────────
+
+    /// <summary>Backing store for <see cref="Label"/>.</summary>
+    public static readonly BindableProperty LabelProperty =
+        BindableProperty.Create(nameof(Label), typeof(string), typeof(MauiActionButtonDefinition), string.Empty);
+
+    /// <summary>Backing store for <see cref="BackgroundColor"/>.</summary>
+    public static readonly BindableProperty BackgroundColorProperty =
+        BindableProperty.Create(nameof(BackgroundColor), typeof(GridColor), typeof(MauiActionButtonDefinition), new GridColor(13, 110, 253));
+
+    /// <summary>Backing store for <see cref="TextColor"/>.</summary>
+    public static readonly BindableProperty TextColorProperty =
+        BindableProperty.Create(nameof(TextColor), typeof(GridColor), typeof(MauiActionButtonDefinition), GridColor.White);
+
+    /// <summary>Backing store for <see cref="Command"/>.</summary>
+    public static readonly BindableProperty CommandProperty =
+        BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(MauiActionButtonDefinition), null);
+
+    /// <summary>Backing store for <see cref="CommandParameter"/>.</summary>
+    public static readonly BindableProperty CommandParameterProperty =
+        BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(MauiActionButtonDefinition), null);
+
+    // ── Properties ───────────────────────────────────────────────
+
+    /// <summary>Text label rendered on the button face.</summary>
+    public string Label
+    {
+        get => (string)GetValue(LabelProperty);
+        set => SetValue(LabelProperty, value);
+    }
+
+    /// <summary>
+    /// Button pill background color.
+    /// Supports the <c>R,G,B</c> / <c>#RRGGBB</c> / named-color string formats
+    /// from <see cref="GridColorTypeConverter"/> in XAML.
+    /// </summary>
+    public GridColor BackgroundColor
+    {
+        get => (GridColor)GetValue(BackgroundColorProperty);
+        set => SetValue(BackgroundColorProperty, value);
+    }
+
+    /// <summary>Button label text color. Defaults to <see cref="GridColor.White"/>.</summary>
+    public GridColor TextColor
+    {
+        get => (GridColor)GetValue(TextColorProperty);
+        set => SetValue(TextColorProperty, value);
+    }
+
+    /// <summary>
+    /// Command executed when this button is tapped.
+    /// Bind to a ViewModel command using:
+    /// <c>{Binding Path=BindingContext.MyCommand, Source={x:Reference gridName}}</c>
+    /// </summary>
+    public ICommand? Command
+    {
+        get => (ICommand?)GetValue(CommandProperty);
+        set => SetValue(CommandProperty, value);
+    }
+
+    /// <summary>
+    /// Explicit command parameter. When <see langword="null"/>, the row item
+    /// (<see cref="KumikoUI.Core.Components.DrawnActionButtons.RowItem"/>) is passed
+    /// to <see cref="Command"/> at runtime.
+    /// </summary>
+    public object? CommandParameter
+    {
+        get => GetValue(CommandParameterProperty);
+        set => SetValue(CommandParameterProperty, value);
+    }
+
+    /// <summary>
+    /// Optional callback invoked when the button is tapped (code-behind alternative
+    /// to <see cref="Command"/>). Ignored by the display-only renderer.
+    /// </summary>
+    public Action? Action { get; set; }
+}

--- a/tests/KumikoUI.Core.Tests/DataGridSourceTests.cs
+++ b/tests/KumikoUI.Core.Tests/DataGridSourceTests.cs
@@ -900,3 +900,9 @@ public class DataGridSourceTests
         Assert.Null(ex);
     }
 }
+
+
+
+
+
+


### PR DESCRIPTION
Introduce `DrawnActionButtons` and `ActionButtonsCellRenderer` to support clickable row actions. This allows developers to trigger commands or navigation directly from grid cells with immediate touch response.
