### PR TITLE
Add GitHub Copilot instructions, scoped instruction files, and skill prompts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,98 @@
+# KumikoUI — Copilot Instructions Index
+
+## What This Project Is
+
+**KumikoUI** is a high-performance, fully canvas-drawn DataGrid for .NET MAUI. Every visual
+element — cells, headers, editors, popups, scrollbars — is rendered directly on a SkiaSharp
+`SKCanvas`. There are **zero native UIKit / AppKit / WinUI controls**; everything is drawn
+in software, giving pixel-perfect, identical output across iOS, Android, macOS Catalyst, and
+Windows.
+
+---
+
+## Scoped Instruction Files
+
+Detailed instructions live in [`.github/instructions/`](.github/instructions/) and are
+automatically injected based on which files are open. When a task spans multiple areas,
+read the relevant files directly — each is self-contained.
+
+---
+
+### [architecture.instructions.md](.github/instructions/architecture.instructions.md)
+**Applies to:** all files (`**`)
+
+Always-active baseline. Covers: three-layer project structure (`Core` → `SkiaSharp` → `Maui`),
+strict dependency rules, full namespace map, and repo-wide C# code style rules (nullable,
+`readonly struct`, no LINQ in hot paths, `GridColor` usage, `float` for coordinates).
+
+---
+
+### [rendering.instructions.md](.github/instructions/rendering.instructions.md)
+**Applies to:** `src/KumikoUI.Core/Rendering/**`, `src/KumikoUI.SkiaSharp/**`, `src/KumikoUI.Core/DataGridRenderer.cs`
+
+Everything about drawing. Covers: all `IDrawingContext` methods, `GridPaint`/`GridColor`/`GridRect`
+usage, `ICellRenderer` interface + how to attach custom renderers to columns, `DataGridRenderer`
+render-loop structure and z-order, `PaintCache`, `SkiaDrawingContext` internals (per-frame
+paint/font cache, SkiaSharp 3.x API), `GridLayoutEngine` layout methods, and performance rules
+(no allocation, no LINQ, virtual scrolling).
+
+---
+
+### [components-and-editing.instructions.md](.github/instructions/components-and-editing.instructions.md)
+**Applies to:** `src/KumikoUI.Core/Components/**`, `src/KumikoUI.Core/Editing/**`
+
+Everything about canvas-drawn editors. Covers: `DrawnComponent` lifecycle overrides, the three
+signals (`InvalidateVisual`, `RaiseValueChanged`, `RaiseEditCompleted`), the `ApplyTheme` pattern,
+`CellEditorFactory` wiring (three required cases per editor type), `EditorDescriptor` for XAML-
+declarable editor config, `EditSession` pipeline (begin → draw → commit/cancel), validation via
+`IDataErrorInfo` or delegate, and `InertialScroller` physics.
+
+---
+
+### [models-and-data.instructions.md](.github/instructions/models-and-data.instructions.md)
+**Applies to:** `src/KumikoUI.Core/Models/**`
+
+Everything about the data layer. Covers: all `DataGridColumn` properties and column types,
+`DataGridSource` API (get/set values, bulk updates, sorting, filtering, grouping, summaries),
+`DataGridStyle` theming (built-in themes, `CellStyleResolver`, `RowStyleResolver`), `CellStyle`/
+`RowStyle` nullable merge semantics, and step-by-step recipes for adding a new style property
+or column type.
+
+---
+
+### [maui-control.instructions.md](.github/instructions/maui-control.instructions.md)
+**Applies to:** `src/KumikoUI.Maui/**`, `samples/**`
+
+Everything about consuming the control. Covers: `MauiProgram.UseSkiaKumikoUI()` bootstrap,
+required XAML namespaces, all `DataGridView` bindable properties, XAML examples for every column
+type (Numeric, Text, ComboBox, Picker, Date, Boolean, Template with renderer, Template with
+`EditorDescriptor`), summary row XAML, and `DataGridView` internals (keyboard proxy, platform-
+specific gesture/IME handling, timer setup).
+
+---
+
+### [testing.instructions.md](.github/instructions/testing.instructions.md)
+**Applies to:** `tests/**`
+
+Everything about writing tests. Covers: xUnit-only rules (no NUnit/MSTest), file/class naming
+convention, `[Fact]` and `[Theory]+[InlineData]` templates, a concrete `DataGridSource` sorting
+example, and the `FakeDrawingContext` no-op test double needed to test renderers and components
+without SkiaSharp.
+
+---
+
+## Skill Prompts
+
+Reusable task prompts live in [`.github/prompts/`](.github/prompts/):
+
+| Prompt | Use when... |
+|---|---|
+| [`add-cell-renderer.prompt.md`](.github/prompts/add-cell-renderer.prompt.md) | Creating a new `ICellRenderer` |
+| [`add-drawn-component.prompt.md`](.github/prompts/add-drawn-component.prompt.md) | Creating a new canvas-drawn inline editor |
+| [`add-column-type.prompt.md`](.github/prompts/add-column-type.prompt.md) | Adding a new `DataGridColumnType` end-to-end |
+| [`add-theme-property.prompt.md`](.github/prompts/add-theme-property.prompt.md) | Adding a new `DataGridStyle` visual property |
+| [`add-unit-test.prompt.md`](.github/prompts/add-unit-test.prompt.md) | Writing xUnit tests for Core classes |
+| [`configure-datagrid-features.prompt.md`](.github/prompts/configure-datagrid-features.prompt.md) | Wiring sorting, filtering, grouping, or summaries |
+| [`rendering-pipeline.prompt.md`](.github/prompts/rendering-pipeline.prompt.md) | Debugging or extending the render pipeline |
+
+---

--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -1,0 +1,72 @@
+---
+applyTo: "**"
+---
+
+# KumikoUI — Architecture & Project Structure
+
+## What This Is
+
+**KumikoUI** is a high-performance, fully canvas-drawn DataGrid for .NET MAUI. Every visual
+element is rendered on a SkiaSharp `SKCanvas` — zero native UIKit / AppKit / WinUI controls,
+pixel-perfect across iOS, Android, macOS Catalyst, and Windows.
+
+---
+
+## Three-Layer Architecture
+
+```
+KumikoUI.Core         net9.0          — platform-agnostic models, layout, rendering pipeline
+KumikoUI.SkiaSharp    net9.0          — IDrawingContext → SKCanvas implementation
+KumikoUI.Maui         net10.0-*maui*  — DataGridView control, SKCanvasView host
+```
+
+**Dependency direction — strict, never violate:**
+```
+KumikoUI.Core  ←  KumikoUI.SkiaSharp  ←  KumikoUI.Maui
+```
+
+| Layer | May reference | Must NOT reference |
+|---|---|---|
+| `KumikoUI.Core` | BCL only | SkiaSharp, MAUI, any platform SDK |
+| `KumikoUI.SkiaSharp` | Core + `SkiaSharp` NuGet | MAUI, platform SDKs |
+| `KumikoUI.Maui` | Core, SkiaSharp, MAUI | (no restriction) |
+
+---
+
+## Project Paths
+
+| Purpose | Path |
+|---|---|
+| Core models, layout, rendering abstractions | `src/KumikoUI.Core/` |
+| SkiaSharp drawing context | `src/KumikoUI.SkiaSharp/` |
+| MAUI control + hosting | `src/KumikoUI.Maui/` |
+| Sample app | `samples/SampleApp.Maui/` |
+| xUnit tests | `tests/KumikoUI.Core.Tests/` |
+
+---
+
+## Namespace Map
+
+| Namespace | Key types |
+|---|---|
+| `KumikoUI.Core.Models` | `DataGridColumn`, `DataGridStyle`, `DataGridSource`, `SelectionModel`, `ScrollState`, `CellStyle`, `RowStyle`, `FilterDescription`, `GroupDescription`, `TableSummaryRow`, `SummaryColumnDescription` |
+| `KumikoUI.Core.Rendering` | `IDrawingContext`, `ICellRenderer`, `GridRect`, `GridColor`, `GridPaint`, `GridFont`, `GridSize`, `GridFontMetrics`, `PaintStyle`, `GridTextAlignment`, `GridVerticalAlignment` |
+| `KumikoUI.Core.Layout` | `GridLayoutEngine` |
+| `KumikoUI.Core.Input` | `GridInputController`, `InertialScroller`, `ScrollSettings`, `GridPointerEventArgs`, `GridKeyEventArgs`, `HitTesting` |
+| `KumikoUI.Core.Editing` | `EditSession`, `CellEditorFactory`, `EditorDescriptor`, `EditTrigger`, `CellValidationResult` |
+| `KumikoUI.Core.Components` | `DrawnComponent`, `DrawnTextBox`, `DrawnComboBox`, `DrawnDatePicker`, `DrawnNumericUpDown`, `DrawnScrollPicker`, `DrawnCheckBox`, `DrawnFilterPopup`, `FocusManager`, `PopupManager` |
+| `KumikoUI.SkiaSharp` | `SkiaDrawingContext` |
+| `KumikoUI.Maui` | `DataGridView`, `DataGridHostingExtensions` |
+
+---
+
+## Code Style (applies everywhere)
+
+- **C# 12+**, nullable reference types enabled project-wide.
+- All public API members have `/// <summary>` XML doc comments.
+- `readonly struct` for value types (`GridRect`, `GridSize`, `CellPosition`).
+- `record struct` for cache keys in `SkiaDrawingContext`.
+- Prefer `switch` expressions over `if/else` chains for type dispatch.
+- **No LINQ** inside render-loop hot paths — use `for` loops.
+- Use `float` for all coordinate/dimension math (not `double`).
+- Use `GridColor(r, g, b[, a])` everywhere — never hex strings, never `SKColor`, never `Color` from MAUI.

--- a/.github/instructions/components-and-editing.instructions.md
+++ b/.github/instructions/components-and-editing.instructions.md
@@ -1,0 +1,163 @@
+---
+applyTo: "src/KumikoUI.Core/Components/**,src/KumikoUI.Core/Editing/**"
+---
+
+# KumikoUI — Drawn Components & Editing
+
+## `DrawnComponent` — Canvas-drawn editors (no native controls)
+
+All inline cell editors inherit from `DrawnComponent` in `KumikoUI.Core.Components`.
+There are **zero native UIKit / WinUI / Android widgets** — everything is drawn on canvas.
+
+### Minimum implementation
+
+```csharp
+public class MyEditor : DrawnComponent
+{
+    public override void OnDraw(IDrawingContext ctx)
+    {
+        // Draw inside this.Bounds using IDrawingContext only.
+        ctx.FillRect(Bounds, new GridPaint { Color = new GridColor(255, 255, 255) });
+    }
+}
+```
+
+### Lifecycle overrides
+
+| Method | When called |
+|---|---|
+| `OnDraw(IDrawingContext ctx)` | **Required.** Every repaint. |
+| `OnPointerDown(GridPointerEventArgs e)` | Touch / mouse press |
+| `OnPointerUp(GridPointerEventArgs e)` | Touch / mouse release |
+| `OnPointerMove(GridPointerEventArgs e)` | Touch / mouse drag |
+| `OnKeyDown(GridKeyEventArgs e)` | Key press (set `e.Handled = true` to consume) |
+| `OnKeyUp(GridKeyEventArgs e)` | Key release |
+| `OnGotFocus()` | Component gained keyboard focus |
+| `OnLostFocus()` | Component lost focus |
+| `OnBoundsChanged()` | `Bounds` property changed |
+
+### Signals
+
+```csharp
+InvalidateVisual();              // request repaint — call whenever visual state changes
+RaiseValueChanged(old, new);     // consumed by EditSession — call when value changes
+RaiseEditCompleted();            // grid commits + closes editor — call on confirm gesture
+```
+
+### Theming hook
+
+Add `public void ApplyTheme(DataGridStyle style)` — no interface required.
+`CellEditorFactory.ApplyThemeToEditor()` dispatches to it via `switch`.
+
+```csharp
+public void ApplyTheme(DataGridStyle style)
+{
+    _backgroundColor = style.EditorBackgroundColor;
+    _foregroundColor  = style.EditorTextColor;
+    _accentColor      = style.SelectionColor;
+    InvalidateVisual();
+}
+```
+
+### `CellEditorFactory` — three required cases per editor type
+
+```csharp
+// 1. CreateEditor:
+case DataGridColumnType.{NewType}:
+    return new MyEditor { Bounds = cellBounds, Value = ({T}?)currentValue ?? default };
+
+// 2. GetEditorValue:
+case MyEditor e:
+    return e.Value;
+
+// 3. ApplyThemeToEditor:
+case MyEditor e:
+    e.ApplyTheme(style);
+    break;
+```
+
+---
+
+## `EditorDescriptor` — XAML-declarable editor configuration
+
+Subclass `EditorDescriptor` to let column authors configure the editor in XAML without code-behind.
+
+```csharp
+public class MyEditorDescriptor : EditorDescriptor
+{
+    public double Minimum { get; set; } = 0;
+    public double Maximum { get; set; } = 100;
+
+    public override DrawnComponent? CreateEditor(object? currentValue, GridRect cellBounds)
+        => new MyEditor { Bounds = cellBounds, Minimum = Minimum, Maximum = Maximum };
+}
+```
+
+XAML usage:
+```xml
+<core:DataGridColumn Header="Score" PropertyName="Score" ColumnType="Template" Width="120">
+    <core:DataGridColumn.EditorDescriptor>
+        <editing:MyEditorDescriptor Minimum="0" Maximum="10" />
+    </core:DataGridColumn.EditorDescriptor>
+</core:DataGridColumn>
+```
+
+Built-in descriptors: `NumericUpDownEditorDescriptor`, `TextEditorDescriptor`.
+
+---
+
+## `EditSession` — Cell editing pipeline
+
+```
+BeginEdit(row, col, column, dataSource, cellBounds, initialChar?)
+  → CellEditorFactory.CreateEditor(...)
+  → CellEditorFactory.ApplyThemeToEditor(...)
+  → EditSession.DrawEditor(ctx)        ← called each frame after main render
+  → CommitEdit(dataSource)             ← writes value back via DataGridSource.SetCellValue
+    or CancelEdit()
+```
+
+**Events:** `CellBeginEdit` (cancelable), `CellEndEdit`, `CellValueChanged`
+
+**Validation:**
+```csharp
+// Option A — implement on model:
+class Employee : IDataErrorInfo { ... }
+
+// Option B — delegate:
+editSession.CellValidator = (row, col, value) =>
+    value is int i && i >= 1 && i <= 5
+        ? CellValidationResult.Success
+        : CellValidationResult.Error("Value must be 1–5");
+```
+
+---
+
+## `InertialScroller`
+
+```csharp
+var scroller = new InertialScroller { Settings = new ScrollSettings { Friction = 0.92f } };
+
+scroller.TrackVelocity(dx, dy, timestampMs);   // during pan
+scroller.StartFling();                          // on pointer release
+
+if (scroller.IsActive)
+{
+    var (dx, dy) = scroller.Update(frameIntervalMs: 16f);
+    scroll.ScrollBy(-dx, -dy);
+    // trigger repaint
+}
+```
+
+---
+
+## Checklist: adding a new `DrawnComponent`
+
+- [ ] Class in `src/KumikoUI.Core/Components/`, named `Drawn{Name}.cs`
+- [ ] Inherits `DrawnComponent`
+- [ ] `OnDraw` uses only `IDrawingContext` + `GridColor`/`GridPaint`/`GridFont`/`GridRect`
+- [ ] `InvalidateVisual()` called on every state change
+- [ ] `RaiseValueChanged(old, new)` called when value changes
+- [ ] `RaiseEditCompleted()` called on confirm gesture
+- [ ] `ApplyTheme(DataGridStyle)` implemented
+- [ ] `CellEditorFactory` updated: `CreateEditor`, `GetEditorValue`, `ApplyThemeToEditor`

--- a/.github/instructions/maui-control.instructions.md
+++ b/.github/instructions/maui-control.instructions.md
@@ -1,0 +1,145 @@
+---
+applyTo: "src/KumikoUI.Maui/**,samples/**"
+---
+
+# KumikoUI — MAUI Control & XAML Usage
+
+## Bootstrap (`MauiProgram.cs`)
+
+```csharp
+builder
+    .UseMauiApp<App>()
+    .UseSkiaKumikoUI();   // required — registers SkiaSharp drawing services
+```
+
+---
+
+## Required XAML namespaces
+
+```xml
+xmlns:dg="clr-namespace:KumikoUI.Maui;assembly=KumikoUI.Maui"
+xmlns:core="clr-namespace:KumikoUI.Core.Models;assembly=KumikoUI.Core"
+xmlns:render="clr-namespace:KumikoUI.Core.Rendering;assembly=KumikoUI.Core"
+xmlns:editing="clr-namespace:KumikoUI.Core.Editing;assembly=KumikoUI.Core"
+```
+
+---
+
+## `DataGridView` — All bindable properties
+
+```xml
+<dg:DataGridView
+    ItemsSource="{Binding Employees}"
+    EditTriggers="DoubleTap,F2Key,Typing"
+    EditTextSelectionMode="SelectAll"
+    DismissKeyboardOnEnter="True"
+    FrozenRowCount="2"
+    RowHeight="36"
+    HeaderHeight="40"
+    GridDescription="Accessible description for screen readers"
+    HorizontalOptions="Fill"
+    VerticalOptions="Fill" />
+```
+
+`EditTriggers` flags: `SingleTap`, `DoubleTap`, `LongPress`, `F2Key`, `Typing`
+
+---
+
+## Minimal column declaration
+
+```xml
+<dg:DataGridView ItemsSource="{Binding Items}">
+    <dg:DataGridView.Columns>
+        <core:DataGridColumn Header="Name" PropertyName="Name" Width="180" />
+    </dg:DataGridView.Columns>
+</dg:DataGridView>
+```
+
+---
+
+## All column types — XAML examples
+
+```xml
+<!-- Numeric, frozen left, read-only -->
+<core:DataGridColumn Header="Id" PropertyName="Id" ColumnType="Numeric"
+                     Width="60" IsReadOnly="True" IsFrozen="True" AllowTabStop="False"
+                     TextAlignment="Right" />
+
+<!-- Text, frozen right -->
+<core:DataGridColumn Header="City" PropertyName="City" Width="130" FreezeMode="Right" />
+
+<!-- ComboBox — items as CSV -->
+<core:DataGridColumn Header="Department" PropertyName="Department" Width="140"
+                     ColumnType="ComboBox"
+                     EditorItemsString="Engineering,Marketing,Sales,HR,Finance" />
+
+<!-- Picker — scroll-wheel -->
+<core:DataGridColumn Header="Level" PropertyName="Level" Width="120"
+                     ColumnType="Picker"
+                     EditorItemsString="Junior,Mid,Senior,Staff,Principal" />
+
+<!-- Date -->
+<core:DataGridColumn Header="Hire Date" PropertyName="HireDate" Width="120"
+                     ColumnType="Date" Format="yyyy-MM-dd" />
+
+<!-- Boolean -->
+<core:DataGridColumn Header="Active" PropertyName="IsActive" Width="80"
+                     ColumnType="Boolean" AllowTabStop="False" />
+
+<!-- Template — custom renderer (display only) -->
+<core:DataGridColumn Header="Performance" PropertyName="Performance"
+                     ColumnType="Template" Width="140" IsReadOnly="True">
+    <core:DataGridColumn.CustomCellRenderer>
+        <render:ProgressBarCellRenderer Minimum="0" Maximum="100"
+                                        TrackHeight="12" CornerRadius="6"
+                                        ShowText="True" TextFormat="N0" />
+    </core:DataGridColumn.CustomCellRenderer>
+</core:DataGridColumn>
+
+<!-- Template — declarative editor -->
+<core:DataGridColumn Header="Rating" PropertyName="Rating"
+                     ColumnType="Template" Width="100">
+    <core:DataGridColumn.EditorDescriptor>
+        <editing:NumericUpDownEditorDescriptor Minimum="1" Maximum="5"
+                                               Step="1" DecimalPlaces="0" />
+    </core:DataGridColumn.EditorDescriptor>
+</core:DataGridColumn>
+```
+
+---
+
+## Summary rows in XAML
+
+```xml
+<dg:DataGridView.TableSummaryRows>
+    <core:TableSummaryRow Name="Averages" Position="Top" Title="Averages">
+        <core:TableSummaryRow.Columns>
+            <core:SummaryColumnDescription PropertyName="Salary"
+                                           SummaryType="Average" Format="C0" />
+            <core:SummaryColumnDescription PropertyName="Rating"
+                                           SummaryType="Average" Format="N1" />
+        </core:TableSummaryRow.Columns>
+    </core:TableSummaryRow>
+
+    <core:TableSummaryRow Name="Totals" Position="Bottom" Title="Totals">
+        <core:TableSummaryRow.Columns>
+            <core:SummaryColumnDescription PropertyName="Salary"
+                                           SummaryType="Sum" Format="C0" />
+            <core:SummaryColumnDescription PropertyName="Id"
+                                           SummaryType="Count" Label="Rows: " />
+        </core:TableSummaryRow.Columns>
+    </core:TableSummaryRow>
+</dg:DataGridView.TableSummaryRows>
+```
+
+---
+
+## `DataGridView` internals (for platform-specific work)
+
+- Extends `Grid`; contains `SKCanvasView` (render surface) + hidden `Entry` (keyboard proxy).
+- `[ContentProperty(nameof(Columns))]` — columns are XAML content.
+- Double-tap: 400 ms threshold, 20 px distance.
+- Long-press: 500 ms, 15 px tolerance.
+- Android IME: zero-width-space (`\u200B`) sentinel for backspace detection.
+- iOS/macCatalyst: `KeyInputResponder` (native UIKit) + `UIPanGestureRecognizer`.
+- Inertial scroll and cursor blink use `IDispatcherTimer`.

--- a/.github/instructions/models-and-data.instructions.md
+++ b/.github/instructions/models-and-data.instructions.md
@@ -1,0 +1,183 @@
+---
+applyTo: "src/KumikoUI.Core/Models/**"
+---
+
+# KumikoUI — Models & Data
+
+## `DataGridColumn` — Column definition
+
+```csharp
+new DataGridColumn
+{
+    Header          = "Name",
+    PropertyName    = "Name",           // nested paths supported: "Address.City"
+    ColumnType      = DataGridColumnType.Text,
+    Width           = 180f,
+    SizeMode        = ColumnSizeMode.Fixed,   // Fixed | Star | Auto
+    StarWeight      = 1f,
+    MinWidth        = 40f,
+    MaxWidth        = float.MaxValue,
+    IsReadOnly      = false,
+    AllowSorting    = true,
+    AllowFiltering  = true,
+    AllowResize     = true,
+    AllowReorder    = true,
+    AllowTabStop    = true,
+    FreezeMode      = ColumnFreezeMode.None,  // None | Left | Right
+    Format          = "C2",                   // IFormattable format string
+    TextAlignment   = GridTextAlignment.Left,
+    CustomCellRenderer  = null,
+    EditorDescriptor    = null,
+    CustomEditorFactory = null,
+    EditorItems         = null,
+    EditorItemsString   = "A,B,C",            // XAML-friendly CSV for Picker/ComboBox
+    CellStyle           = null,
+    HeaderCellStyle     = null
+};
+```
+
+### Column types
+
+| `DataGridColumnType` | Cell renderer | Inline editor |
+|---|---|---|
+| `Text` | `TextCellRenderer` | `DrawnTextBox` |
+| `Numeric` | `TextCellRenderer` | `DrawnTextBox` (numeric-only) |
+| `Boolean` | `BooleanCellRenderer` | toggle in-place |
+| `Date` | `TextCellRenderer` | `DrawnDatePicker` |
+| `ComboBox` | `TextCellRenderer` | `DrawnComboBox` |
+| `Picker` | `TextCellRenderer` | `DrawnScrollPicker` |
+| `Image` | `ImageCellRenderer` | (not editable) |
+| `Template` | `CustomCellRenderer` or text | `CustomEditorFactory` or `EditorDescriptor` |
+
+---
+
+## `DataGridSource` — Data pipeline
+
+Manages filtering, sorting, grouping, and the flat view used by the renderer.
+
+```csharp
+source.GetCellValue(rowIndex, column)          // raw value
+source.GetCellDisplayText(rowIndex, column)    // formatted string
+source.SetCellValue(rowIndex, column, value)   // write-back
+source.GetItem(rowIndex)                       // raw data item
+source.RowCount                                // visible row count (after filter/group)
+source.Columns                                 // column list
+
+// Bulk updates:
+source.BeginUpdate();
+// ... many add/remove operations
+source.EndUpdate();
+```
+
+### Sorting
+
+```csharp
+source.ApplySort(column);                         // cycles None → Asc → Desc → None
+source.ApplySort(column, SortDirection.Ascending);
+
+// Multi-column:
+col1.SortDirection = SortDirection.Ascending; col1.SortOrder = 1;
+col2.SortDirection = SortDirection.Descending; col2.SortOrder = 2;
+source.ApplySorts();
+```
+
+### Filtering
+
+```csharp
+var filter = new FilterDescription(column)
+{
+    Condition1 = new FilterCondition
+    {
+        TextOperator = TextFilterOperator.Contains,
+        Value        = "Engineering"
+    }
+};
+source.ApplyFilter(column, filter);   // pass null to clear
+
+// Numeric range:
+var numFilter = new FilterDescription(numericColumn)
+{
+    Condition1      = new FilterCondition { NumericOperator = NumericFilterOperator.GreaterThan, Value = 50000d },
+    LogicalOperator = FilterLogicalOperator.And,
+    Condition2      = new FilterCondition { NumericOperator = NumericFilterOperator.LessThanOrEqual, Value = 150000d }
+};
+```
+
+### Grouping
+
+```csharp
+source.GroupDescriptions.Add(new GroupDescription("Department"));
+source.GroupDescriptions.Add(new GroupDescription("City"));    // multi-level
+source.RebuildView();   // required after changing GroupDescriptions
+
+// Custom key display:
+source.GroupDescriptions.Add(new GroupDescription("HireDate")
+{
+    DisplayTextSelector = key => key is DateTime dt ? dt.ToString("yyyy") : key?.ToString() ?? ""
+});
+```
+
+### Summaries
+
+```csharp
+// Table-level:
+var row = new TableSummaryRow("Totals", SummaryPosition.Bottom)
+{
+    Title   = "Totals",
+    Columns =
+    {
+        new SummaryColumnDescription("Salary", SummaryType.Sum)   { Format = "C0" },
+        new SummaryColumnDescription("Id",     SummaryType.Count) { Label = "Rows: " },
+        new SummaryColumnDescription("Rating", SummaryType.Max)   { Label = "Best: " }
+    }
+};
+```
+
+`SummaryType` values: `Sum`, `Average`, `Count`, `Min`, `Max`, `Custom`.
+
+---
+
+## `DataGridStyle` — Theming
+
+```csharp
+// Built-in themes:
+DataGridTheme.Create(DataGridThemeMode.Light)
+DataGridTheme.Create(DataGridThemeMode.Dark)
+DataGridTheme.Create(DataGridThemeMode.HighContrast)
+
+// Dynamic per-cell styling:
+style.CellStyleResolver = (item, column) =>
+    item is Employee e && !e.IsActive
+        ? new CellStyle { TextColor = new GridColor(180, 0, 0) }
+        : null;
+
+// Dynamic per-row styling:
+style.RowStyleResolver = item =>
+    item is Employee e && e.Salary > 200_000
+        ? new RowStyle { BackgroundColor = new GridColor(255, 250, 220) }
+        : null;
+```
+
+### `CellStyle` / `RowStyle` nullable properties
+
+All properties are nullable — `null` means "inherit from grid-level `DataGridStyle`".
+`CellStyle.Merge(primary, fallback)` combines two instances with `primary` taking precedence.
+
+---
+
+## Adding a new `DataGridStyle` property
+
+1. Add property (with `///` XML doc) to `DataGridStyle` in `GridState.cs`.
+2. Set value in `DataGridTheme.CreateDark()` and `DataGridTheme.CreateHighContrast()`.
+3. Use in `DataGridRenderer.cs`.
+4. Add `[Fact]` tests in `DataGridThemeTests.cs` for Dark and HighContrast values.
+
+---
+
+## Adding a new `DataGridColumnType`
+
+1. Add enum value to `DataGridColumnType` in `DataGridColumn.cs`.
+2. Create cell renderer in `src/KumikoUI.Core/Rendering/` (if display differs from text).
+3. Create editor (`DrawnComponent`) in `src/KumikoUI.Core/Components/` (if needed).
+4. Wire `CellEditorFactory`: `CreateEditor`, `GetEditorValue`, `ApplyThemeToEditor`.
+5. Dispatch in `DataGridRenderer.cs` to the renderer.

--- a/.github/instructions/rendering.instructions.md
+++ b/.github/instructions/rendering.instructions.md
@@ -1,0 +1,168 @@
+---
+applyTo: "src/KumikoUI.Core/Rendering/**,src/KumikoUI.SkiaSharp/**,src/KumikoUI.Core/DataGridRenderer.cs"
+---
+
+# KumikoUI — Rendering Pipeline
+
+## `IDrawingContext` — The Only Drawing API
+
+All drawing goes through `IDrawingContext`. **Never call SkiaSharp APIs from Core.**
+`SkiaDrawingContext` (in `KumikoUI.SkiaSharp`) maps these to `SKCanvas`.
+
+```csharp
+void DrawRect(GridRect rect, GridPaint paint);
+void FillRect(GridRect rect, GridPaint paint);
+void DrawRoundRect(GridRect rect, float cornerRadius, GridPaint paint);
+void FillRoundRect(GridRect rect, float cornerRadius, GridPaint paint);
+void DrawLine(float x1, float y1, float x2, float y2, GridPaint paint);
+void DrawText(string text, float x, float y, GridPaint paint);
+void DrawTextInRect(string text, GridRect rect, GridPaint paint,
+    GridTextAlignment hAlign = GridTextAlignment.Left,
+    GridVerticalAlignment vAlign = GridVerticalAlignment.Center,
+    bool clip = true);
+GridSize MeasureText(string text, GridPaint paint);
+GridFontMetrics GetFontMetrics(GridPaint paint);
+void ClipRect(GridRect rect);
+void Save();
+void Restore();
+void Translate(float dx, float dy);
+void DrawImage(object image, GridRect destRect);
+```
+
+---
+
+## `GridPaint` — Describe how to draw
+
+```csharp
+var paint = new GridPaint
+{
+    Color       = new GridColor(r, g, b),   // or (r, g, b, a)
+    StrokeWidth = 1.5f,
+    Style       = PaintStyle.Fill,           // Fill | Stroke | FillAndStroke
+    IsAntiAlias = true,
+    Font        = new GridFont("Default", 13, bold: false)
+};
+```
+
+Never construct `SKPaint`, `SKFont`, or `SKColor` in Core. `SkiaDrawingContext` caches
+all Skia objects per frame; they are disposed at end-of-frame.
+
+## `GridColor`
+
+```csharp
+new GridColor(r, g, b)      // alpha = 255
+new GridColor(r, g, b, a)   // explicit alpha
+GridColor.White / GridColor.Black
+```
+
+## `GridRect`
+
+```csharp
+new GridRect(x, y, width, height)
+rect.Inflate(dx, dy)    // expanded copy
+rect.Offset(dx, dy)     // shifted copy
+rect.Contains(px, py)   // hit test
+rect.Left / .Top / .Right / .Bottom
+```
+
+---
+
+## `ICellRenderer` — Custom cell display
+
+```csharp
+public class MyRenderer : ICellRenderer
+{
+    public void Render(
+        IDrawingContext ctx,
+        GridRect cellRect,       // padded cell area — stay inside this
+        object? value,           // raw value from DataGridSource
+        string displayText,      // formatted via DataGridColumn.Format
+        DataGridColumn column,
+        DataGridStyle style,
+        bool isSelected,
+        CellStyle? cellStyle = null)
+    {
+        // Use ctx.* only. No SkiaSharp. No allocation.
+    }
+}
+```
+
+Built-in renderers: `TextCellRenderer`, `BooleanCellRenderer`, `ImageCellRenderer`, `ProgressBarCellRenderer`.
+
+Attach to column:
+```csharp
+column.CustomCellRenderer = new MyRenderer();   // code
+```
+```xml
+<core:DataGridColumn.CustomCellRenderer>
+    <render:MyRenderer />
+</core:DataGridColumn.CustomCellRenderer>
+```
+
+---
+
+## `DataGridRenderer` — Render loop structure
+
+```
+DataGridView.OnPaintSurface
+  └─ DataGridRenderer.Render(IDrawingContext, ...)
+       ├─ DrawHeaderRow          — headers, sort indicator, filter icon, resize handle
+       ├─ DrawFrozenRows         — pinned-top data rows
+       ├─ DrawScrollableArea     — virtual row loop (visible rows only)
+       │    └─ DrawDataRow → DrawCell → ICellRenderer.Render
+       ├─ DrawFrozenColumns      — left/right frozen column overlays
+       ├─ DrawGroupHeaders       — expandable group header rows
+       ├─ DrawSummaryRows        — table-level summary rows (top/bottom)
+       ├─ DrawGroupSummaryRows   — per-group summary rows
+       ├─ DrawActiveEditor       — DrawnComponent overlay (always last data layer)
+       ├─ DrawScrollbars         — canvas-drawn scrollbars
+       └─ DrawRowDragOverlay     — drag-reorder ghost
+```
+
+Adding a new draw pass: add a `private void Draw{Feature}(IDrawingContext ctx, ...)` method
+and call it from `Render(...)` at the correct z-order. Always wrap clip/translate in `Save()`/`Restore()`.
+
+---
+
+## `PaintCache`
+
+`KumikoUI.Core.Rendering.PaintCache` holds pre-built `GridPaint` instances derived from
+`DataGridStyle`. When adding new style-driven paints, add them to `PaintCache` and rebuild
+it on theme change.
+
+---
+
+## `SkiaDrawingContext` — SkiaSharp internals
+
+- Per-frame cache: `GetOrCreatePaint(PaintKey)` and `GetOrCreateFont(FontKey)` using `record struct` keys.
+- `IDisposable` — MAUI host disposes at end of every `PaintSurface` frame.
+- Text rendering uses modern SkiaSharp 3.x `SKFont`-based API (not deprecated `SKPaint.TextSize`).
+- Binary-search ellipsis truncation for text overflow.
+- If a new `IDrawingContext` method is needed: **add to the interface in Core first**, then implement in `SkiaDrawingContext`.
+
+---
+
+## Performance Rules
+
+1. **No per-frame heap allocations** — no `new` inside `Render(...)` or methods it calls.
+2. Use `Populate*` variants on `GridLayoutEngine` (write into pre-allocated `List<>`).
+3. No LINQ in any method called from the render loop.
+4. Virtual scrolling: only rows in `GetVisibleRowRange()` and columns in `GetVisibleScrollableColumns()` are drawn.
+5. Frozen column draw passes must **not** apply `scroll.HorizontalOffset`.
+
+---
+
+## `GridLayoutEngine` — Key methods
+
+```csharp
+engine.ComputeColumnWidths(columns, viewportWidth);
+engine.GetVisibleRowRange(scroll, style, totalRows);
+engine.GetVisibleScrollableColumns(columns, scroll, frozenWidth, rightFrozenWidth);
+engine.GetVisibleFrozenColumns(columns);
+engine.GetVisibleRightFrozenColumns(columns, viewportWidth);
+engine.HitTestColumn(columns, contentX);
+engine.HitTestRow(contentY, style, totalRows);
+engine.CalculateAutoFitWidth(column, dataSource, ctx, style);
+// Prefer Populate* variants in the render loop:
+engine.PopulateVisibleScrollableColumns(columns, scroll, frozenWidth, rightFrozenWidth, list);
+```

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,0 +1,118 @@
+---
+applyTo: "tests/**"
+---
+
+# KumikoUI — Unit Testing
+
+## Rules
+
+- Framework: **xUnit** (`[Fact]` and `[Theory]` + `[InlineData]`). Never NUnit or MSTest.
+- One test class per source class — `GridRectTests` for `GridRect`, etc.
+- File name: `{ClassName}Tests.cs`.
+- No SkiaSharp or MAUI dependencies — `KumikoUI.Core` only.
+- Tests target `net9.0`.
+- Run: `dotnet test tests/KumikoUI.Core.Tests/`
+- Filter to one class: `dotnet test --filter "FullyQualifiedName~{ClassName}Tests"`
+
+---
+
+## `[Fact]` — single scenario
+
+```csharp
+[Fact]
+public void {MethodName}_{Scenario}_Returns{Expected}()
+{
+    // Arrange
+    var sut = new {ClassName}();
+
+    // Act
+    var result = sut.{MethodName}(args);
+
+    // Assert
+    Assert.Equal(expected, result);
+}
+```
+
+## `[Theory]` — data-driven
+
+```csharp
+[Theory]
+[InlineData(/* input */, /* expected */)]
+[InlineData(/* input */, /* expected */)]
+public void {MethodName}_{Scenario}({Type} input, {Type} expected)
+{
+    var sut = new {ClassName}();
+    Assert.Equal(expected, sut.{MethodName}(input));
+}
+```
+
+---
+
+## Example: `DataGridSource` sorting
+
+```csharp
+public class DataGridSourceSortingTests
+{
+    private static DataGridSource MakeSource(IList items, List<DataGridColumn> columns)
+    {
+        var source = new DataGridSource();
+        foreach (var col in columns) source.Columns.Add(col);
+        source.ItemsSource = items;
+        return source;
+    }
+
+    [Fact]
+    public void ApplySort_Ascending_OrdersRowsCorrectly()
+    {
+        var items  = new List<Employee>
+        {
+            new() { Id = 3, Name = "Charlie" },
+            new() { Id = 1, Name = "Alice" },
+            new() { Id = 2, Name = "Bob" },
+        };
+        var col    = new DataGridColumn { PropertyName = "Name", ColumnType = DataGridColumnType.Text };
+        var source = MakeSource(items, [col]);
+
+        source.ApplySort(col);
+
+        Assert.Equal("Alice",   source.GetCellDisplayText(0, col));
+        Assert.Equal("Bob",     source.GetCellDisplayText(1, col));
+        Assert.Equal("Charlie", source.GetCellDisplayText(2, col));
+    }
+}
+```
+
+---
+
+## `FakeDrawingContext` — test double for renderers
+
+When testing `ICellRenderer` or `DrawnComponent`, create a no-op `IDrawingContext`:
+
+```csharp
+// tests/KumikoUI.Core.Tests/TestHelpers/FakeDrawingContext.cs
+using KumikoUI.Core.Rendering;
+
+namespace KumikoUI.Core.Tests.TestHelpers;
+
+internal sealed class FakeDrawingContext : IDrawingContext
+{
+    public void DrawRect(GridRect r, GridPaint p) { }
+    public void FillRect(GridRect r, GridPaint p) { }
+    public void DrawRoundRect(GridRect r, float cr, GridPaint p) { }
+    public void FillRoundRect(GridRect r, float cr, GridPaint p) { }
+    public void DrawLine(float x1, float y1, float x2, float y2, GridPaint p) { }
+    public void DrawText(string t, float x, float y, GridPaint p) { }
+    public void DrawTextInRect(string t, GridRect r, GridPaint p,
+        GridTextAlignment h = GridTextAlignment.Left,
+        GridVerticalAlignment v = GridVerticalAlignment.Center,
+        bool clip = true) { }
+    public GridSize MeasureText(string t, GridPaint p) => new GridSize(t.Length * 8, 14);
+    public GridFontMetrics GetFontMetrics(GridPaint p) => new GridFontMetrics(14, 0, 2);
+    public void ClipRect(GridRect r) { }
+    public void Save() { }
+    public void Restore() { }
+    public void Translate(float dx, float dy) { }
+    public void DrawImage(object image, GridRect dest) { }
+    public void Dispose() { }
+}
+```

--- a/.github/prompts/add-cell-renderer.prompt.md
+++ b/.github/prompts/add-cell-renderer.prompt.md
@@ -1,0 +1,164 @@
+---
+mode: agent
+description: Scaffold a new custom ICellRenderer for KumikoUI
+---
+
+# Add a Custom Cell Renderer
+
+Create a new `ICellRenderer` implementation in `src/KumikoUI.Core/Rendering/` to display cell
+values in a custom visual style.
+
+## What to ask the user before generating code
+
+1. What is the **class name** for the renderer? (e.g. `StarRatingCellRenderer`)
+2. What **column type** will it be used with, or is it a `Template` column renderer?
+3. What **configurable properties** does it expose? (min/max, colors, sizes, etc.)
+
+---
+
+## Files to create / modify
+
+| Action | File |
+|---|---|
+| **Create** | `src/KumikoUI.Core/Rendering/{ClassName}.cs` |
+| **Modify** (optional, if new column type) | `src/KumikoUI.Core/Models/DataGridColumn.cs` — add enum value |
+| **Create** | `tests/KumikoUI.Core.Tests/{ClassName}Tests.cs` |
+
+---
+
+## Template
+
+```csharp
+// src/KumikoUI.Core/Rendering/{ClassName}.cs
+using KumikoUI.Core.Models;
+
+namespace KumikoUI.Core.Rendering;
+
+/// <summary>
+/// Renders {description of what it displays} in a data-grid cell.
+/// </summary>
+public class {ClassName} : ICellRenderer
+{
+    // --- Configurable properties --------------------------------------------------
+
+    /// <summary>Minimum value for the range. Default 0.</summary>
+    public float Minimum { get; set; } = 0f;
+
+    /// <summary>Maximum value for the range. Default 100.</summary>
+    public float Maximum { get; set; } = 100f;
+
+    // --- ICellRenderer ------------------------------------------------------------
+
+    /// <inheritdoc />
+    public void Render(
+        IDrawingContext ctx,
+        GridRect cellRect,
+        object? value,
+        string displayText,
+        DataGridColumn column,
+        DataGridStyle style,
+        bool isSelected,
+        CellStyle? cellStyle = null)
+    {
+        // ── Background ────────────────────────────────────────────────────────────
+        var bg = cellStyle?.BackgroundColor
+            ?? (isSelected ? style.SelectionColor : style.CellBackgroundColor);
+
+        ctx.FillRect(cellRect, new GridPaint { Color = bg, Style = PaintStyle.Fill });
+
+        // ── Value parsing ─────────────────────────────────────────────────────────
+        float numericValue = value switch
+        {
+            float f  => f,
+            double d => (float)d,
+            int i    => i,
+            _        => float.TryParse(displayText, out float parsed) ? parsed : 0f
+        };
+
+        float fraction = Maximum > Minimum
+            ? Math.Clamp((numericValue - Minimum) / (Maximum - Minimum), 0f, 1f)
+            : 0f;
+
+        // ── Custom drawing ────────────────────────────────────────────────────────
+        // TODO: implement visual representation using ctx.DrawRect / ctx.FillRect /
+        // ctx.DrawText / ctx.DrawRoundRect etc.
+        //
+        // RULES:
+        //  • Use only IDrawingContext methods — no SkiaSharp APIs.
+        //  • Use GridColor, GridPaint, GridFont from KumikoUI.Core.Rendering.
+        //  • Never hardcode colors; fall back to DataGridStyle properties.
+        //  • Stay within cellRect bounds.
+    }
+}
+```
+
+---
+
+## Attach to a column
+
+### In XAML (Template column)
+
+```xml
+<core:DataGridColumn Header="My Column" PropertyName="Value"
+                     ColumnType="Template" Width="140" IsReadOnly="True">
+    <core:DataGridColumn.CustomCellRenderer>
+        <render:{ClassName} Minimum="0" Maximum="100" />
+    </core:DataGridColumn.CustomCellRenderer>
+</core:DataGridColumn>
+```
+
+### In code
+
+```csharp
+var column = new DataGridColumn
+{
+    Header = "My Column",
+    PropertyName = "Value",
+    ColumnType = DataGridColumnType.Template,
+    Width = 140,
+    IsReadOnly = true,
+    CustomCellRenderer = new {ClassName} { Minimum = 0, Maximum = 100 }
+};
+```
+
+---
+
+## Unit test skeleton
+
+```csharp
+// tests/KumikoUI.Core.Tests/{ClassName}Tests.cs
+using KumikoUI.Core.Models;
+using KumikoUI.Core.Rendering;
+
+public class {ClassName}Tests
+{
+    private static DataGridColumn MakeColumn() =>
+        new DataGridColumn { PropertyName = "Value", ColumnType = DataGridColumnType.Template };
+
+    [Fact]
+    public void Render_WithNullValue_DoesNotThrow()
+    {
+        var renderer = new {ClassName}();
+        var style    = DataGridTheme.Create(DataGridThemeMode.Light);
+        var ctx      = new FakeDrawingContext();
+        renderer.Render(ctx, new GridRect(0, 0, 100, 30), null, "", MakeColumn(), style, false);
+        // No assertion needed — simply must not throw.
+    }
+
+    [Theory]
+    [InlineData(0f,   0f)]
+    [InlineData(50f,  0.5f)]
+    [InlineData(100f, 1f)]
+    public void Fraction_CalculatesCorrectly(float value, float expected)
+    {
+        // Unit test the fraction math independently of drawing.
+        float min = 0f, max = 100f;
+        float fraction = max > min ? Math.Clamp((value - min) / (max - min), 0f, 1f) : 0f;
+        Assert.Equal(expected, fraction, precision: 4);
+    }
+}
+```
+
+> `FakeDrawingContext` is a no-op `IDrawingContext` test double. If it does not yet exist,
+> create `tests/KumikoUI.Core.Tests/TestHelpers/FakeDrawingContext.cs` implementing all
+> interface members as empty stubs.

--- a/.github/prompts/add-column-type.prompt.md
+++ b/.github/prompts/add-column-type.prompt.md
@@ -1,0 +1,148 @@
+---
+mode: agent
+description: Add a new DataGridColumnType and wire it end-to-end in KumikoUI
+---
+
+# Add a New Column Type
+
+Adds a new `DataGridColumnType` enum value and wires it through all five required
+touch-points in the codebase.
+
+## What to ask the user before generating code
+
+1. What is the **enum name** for the new type? (e.g. `Rating`, `Color`, `Url`)
+2. What **value type** does the column display/edit? (`string`, `double`, `int`, `DateOnly`, etc.)
+3. Does it need a **custom cell renderer**, or will the default `TextCellRenderer` suffice for display?
+4. Does it need a **custom inline editor** (`DrawnComponent`), or reuse an existing one?
+5. What XAML **configurable properties** (if any) does the editor expose?
+
+---
+
+## Files to create / modify (all five are required)
+
+| Action | File | What to change |
+|---|---|---|
+| **Modify** | `src/KumikoUI.Core/Models/DataGridColumn.cs` | Add enum value to `DataGridColumnType` |
+| **Create** (if custom renderer) | `src/KumikoUI.Core/Rendering/{Type}CellRenderer.cs` | New `ICellRenderer` |
+| **Create** (if custom editor) | `src/KumikoUI.Core/Components/Drawn{Type}.cs` | New `DrawnComponent` |
+| **Modify** | `src/KumikoUI.Core/Editing/CellEditorFactory.cs` | Add cases for create, get value, apply theme |
+| **Modify** | `src/KumikoUI.Core/DataGridRenderer.cs` | Dispatch new type to cell renderer |
+
+---
+
+## Step 1 — `DataGridColumnType` enum
+
+In `src/KumikoUI.Core/Models/DataGridColumn.cs`, add the new value with a doc comment:
+
+```csharp
+public enum DataGridColumnType
+{
+    Text,
+    Numeric,
+    Boolean,
+    Date,
+    ComboBox,
+    Picker,
+    Image,
+    Template,
+    {NewType},   // ← add here
+}
+```
+
+---
+
+## Step 2 — Cell renderer (display)
+
+Only create a new renderer if the visual appearance differs from text.
+If text display is fine, the existing `TextCellRenderer` will be used automatically.
+
+See `add-cell-renderer.prompt.md` for the full `ICellRenderer` template.
+
+Key rule: implement the renderer inside `KumikoUI.Core.Rendering`; use only
+`IDrawingContext` methods and `GridColor`/`GridPaint`/`GridFont` — no SkiaSharp.
+
+---
+
+## Step 3 — Inline editor
+
+Only create a new editor if existing editors (`DrawnTextBox`, `DrawnComboBox`,
+`DrawnDatePicker`, `DrawnNumericUpDown`, `DrawnScrollPicker`) are insufficient.
+
+See `add-drawn-component.prompt.md` for the full `DrawnComponent` template.
+
+---
+
+## Step 4 — `CellEditorFactory` wiring
+
+In `src/KumikoUI.Core/Editing/CellEditorFactory.cs`, add three cases:
+
+### `CreateEditor`
+```csharp
+case DataGridColumnType.{NewType}:
+    var editor = new Drawn{Type}
+    {
+        Bounds = cellBounds,
+        Value  = ({ValueType}?)currentValue ?? default
+    };
+    if (column.EditorDescriptor is {Type}EditorDescriptor desc)
+        editor.ApplyDescriptor(desc);
+    return editor;
+```
+
+### `GetEditorValue`
+```csharp
+case Drawn{Type} e:
+    return e.Value;
+```
+
+### `ApplyThemeToEditor`
+```csharp
+case Drawn{Type} e:
+    e.ApplyTheme(style);
+    break;
+```
+
+---
+
+## Step 5 — Renderer dispatch
+
+In `src/KumikoUI.Core/DataGridRenderer.cs`, locate the section that selects a
+cell renderer by column type and add a case:
+
+```csharp
+// Inside the method that resolves ICellRenderer for a column:
+DataGridColumnType.{NewType} => new {Type}CellRenderer(),
+// or, if reusing text renderer:
+DataGridColumnType.{NewType} => _textCellRenderer,
+```
+
+---
+
+## Step 6 — Verification checklist
+
+- [ ] `DataGridColumnType.{NewType}` compiles in `KumikoUI.Core`
+- [ ] `CellEditorFactory` switch has `CreateEditor`, `GetEditorValue`, and `ApplyThemeToEditor` cases
+- [ ] `DataGridRenderer` dispatches to the renderer (no missing-case compiler warning)
+- [ ] Can declare column in XAML: `ColumnType="{NewType}"` without error
+- [ ] Edit session opens and closes cleanly with `EditTriggers="DoubleTap"`
+- [ ] Value is written back to `DataGridSource` (test with a bound `ObservableCollection`)
+
+---
+
+## XAML usage example (once implemented)
+
+```xml
+<core:DataGridColumn Header="Rating" PropertyName="Rating"
+                     ColumnType="{NewType}"
+                     Width="120" />
+```
+
+If an `EditorDescriptor` was created:
+```xml
+<core:DataGridColumn Header="Rating" PropertyName="Rating"
+                     ColumnType="{NewType}" Width="120">
+    <core:DataGridColumn.EditorDescriptor>
+        <editing:{Type}EditorDescriptor Minimum="1" Maximum="5" />
+    </core:DataGridColumn.EditorDescriptor>
+</core:DataGridColumn>
+```

--- a/.github/prompts/add-drawn-component.prompt.md
+++ b/.github/prompts/add-drawn-component.prompt.md
@@ -1,0 +1,211 @@
+---
+mode: agent
+description: Scaffold a new DrawnComponent inline cell editor for KumikoUI
+---
+
+# Add a DrawnComponent Editor
+
+Create a new canvas-drawn inline cell editor in `src/KumikoUI.Core/Components/`.
+All editors inherit from `DrawnComponent` — there are **no native UI controls**.
+
+## What to ask the user before generating code
+
+1. What is the **class name**? (e.g. `DrawnColorPicker`, `DrawnTimePicker`)
+2. What **value type** does it edit? (`string`, `double`, `DateTime`, `bool`, etc.)
+3. What **input interactions** are needed? (tap, drag, keyboard, swipe?)
+4. Should it be **declarative via XAML**? If yes, also create an `EditorDescriptor` subclass.
+5. Does it need to **display a popup** (like `DrawnDatePicker` or `DrawnComboBox`)?
+
+---
+
+## Files to create / modify
+
+| Action | File |
+|---|---|
+| **Create** | `src/KumikoUI.Core/Components/Drawn{Name}.cs` |
+| **Create** (if XAML-declarable) | `src/KumikoUI.Core/Editing/{Name}EditorDescriptor.cs` |
+| **Modify** | `src/KumikoUI.Core/Editing/CellEditorFactory.cs` — add case |
+| **Create** | `tests/KumikoUI.Core.Tests/Drawn{Name}Tests.cs` (if logic is testable) |
+
+---
+
+## DrawnComponent template
+
+```csharp
+// src/KumikoUI.Core/Components/Drawn{Name}.cs
+using KumikoUI.Core.Models;
+using KumikoUI.Core.Rendering;
+
+namespace KumikoUI.Core.Components;
+
+/// <summary>
+/// Canvas-drawn {description} editor component.
+/// </summary>
+public class Drawn{Name} : DrawnComponent
+{
+    // ── State ─────────────────────────────────────────────────────────────────────
+
+    private {ValueType} _value;
+    private bool _isPressed;
+
+    // ── Properties ────────────────────────────────────────────────────────────────
+
+    /// <summary>Current value of the editor.</summary>
+    public {ValueType} Value
+    {
+        get => _value;
+        set
+        {
+            if (EqualityComparer<{ValueType}>.Default.Equals(_value, value)) return;
+            var old = _value;
+            _value = value;
+            InvalidateVisual();
+            RaiseValueChanged(old, _value);
+        }
+    }
+
+    // ── Theming ───────────────────────────────────────────────────────────────────
+
+    private GridColor _backgroundColor = new GridColor(255, 255, 255);
+    private GridColor _foregroundColor  = new GridColor(30, 30, 30);
+    private GridColor _accentColor      = new GridColor(0, 120, 215);
+
+    /// <summary>Applies colors from the active DataGridStyle.</summary>
+    public void ApplyTheme(DataGridStyle style)
+    {
+        _backgroundColor = style.EditorBackgroundColor;
+        _foregroundColor  = style.EditorTextColor;
+        _accentColor      = style.SelectionColor;
+        InvalidateVisual();
+    }
+
+    // ── Rendering ─────────────────────────────────────────────────────────────────
+
+    /// <inheritdoc />
+    public override void OnDraw(IDrawingContext ctx)
+    {
+        // Background
+        ctx.FillRect(Bounds, new GridPaint { Color = _backgroundColor, Style = PaintStyle.Fill });
+
+        // Border
+        ctx.DrawRect(Bounds, new GridPaint
+        {
+            Color = _isPressed ? _accentColor : new GridColor(180, 180, 180),
+            Style = PaintStyle.Stroke,
+            StrokeWidth = 1f
+        });
+
+        // TODO: draw the value representation inside Bounds using IDrawingContext methods.
+        // Use GridColor, GridPaint, GridFont, GridRect — never SkiaSharp types.
+    }
+
+    // ── Input ─────────────────────────────────────────────────────────────────────
+
+    /// <inheritdoc />
+    public override void OnPointerDown(GridPointerEventArgs e)
+    {
+        _isPressed = true;
+        InvalidateVisual();
+    }
+
+    /// <inheritdoc />
+    public override void OnPointerUp(GridPointerEventArgs e)
+    {
+        _isPressed = false;
+        // TODO: handle tap confirm
+        InvalidateVisual();
+    }
+
+    /// <inheritdoc />
+    public override void OnKeyDown(GridKeyEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case GridKey.Escape:
+                // Let the edit session handle cancel.
+                break;
+            case GridKey.Enter:
+                RaiseEditCompleted();
+                e.Handled = true;
+                break;
+        }
+    }
+}
+```
+
+---
+
+## `CellEditorFactory` — add cases
+
+In `src/KumikoUI.Core/Editing/CellEditorFactory.cs`:
+
+**`CreateEditor` switch:**
+```csharp
+// add inside CreateEditor(...)  switch (column.ColumnType)
+case DataGridColumnType.{NewType}:
+    return new Drawn{Name}
+    {
+        Bounds = cellBounds,
+        Value = ({ValueType}?)currentValue ?? default
+    };
+```
+
+**`GetEditorValue` switch:**
+```csharp
+case Drawn{Name} e:
+    return e.Value;
+```
+
+**`ApplyThemeToEditor` switch:**
+```csharp
+case Drawn{Name} e:
+    e.ApplyTheme(style);
+    break;
+```
+
+---
+
+## Optional: `EditorDescriptor` (for XAML-declarable config)
+
+```csharp
+// src/KumikoUI.Core/Editing/{Name}EditorDescriptor.cs
+namespace KumikoUI.Core.Editing;
+
+/// <summary>
+/// Declarative configuration for <see cref="Drawn{Name}"/> in XAML.
+/// </summary>
+public class {Name}EditorDescriptor : EditorDescriptor
+{
+    // TODO: add configurable properties
+    public int SomeOption { get; set; } = 1;
+
+    /// <inheritdoc />
+    public override DrawnComponent? CreateEditor(object? currentValue, GridRect cellBounds)
+        => new Drawn{Name}
+        {
+            Bounds = cellBounds,
+            Value  = ({ValueType}?)currentValue ?? default
+        };
+}
+```
+
+**XAML usage:**
+```xml
+<core:DataGridColumn Header="..." PropertyName="..." ColumnType="Template" Width="120">
+    <core:DataGridColumn.EditorDescriptor>
+        <editing:{Name}EditorDescriptor SomeOption="42" />
+    </core:DataGridColumn.EditorDescriptor>
+</core:DataGridColumn>
+```
+
+---
+
+## Rules checklist
+
+- [ ] Class is in namespace `KumikoUI.Core.Components`
+- [ ] No SkiaSharp APIs — only `IDrawingContext` primitives and `GridColor`/`GridPaint`/`GridFont`
+- [ ] `InvalidateVisual()` called whenever visual state changes
+- [ ] `RaiseValueChanged(old, new)` called when value changes
+- [ ] `RaiseEditCompleted()` called when the user confirms their selection
+- [ ] `ApplyTheme(DataGridStyle)` implemented (no interface — `CellEditorFactory` calls it via `switch`)
+- [ ] `CellEditorFactory` updated with `CreateEditor`, `GetEditorValue`, and `ApplyThemeToEditor` cases

--- a/.github/prompts/add-theme-property.prompt.md
+++ b/.github/prompts/add-theme-property.prompt.md
@@ -1,0 +1,109 @@
+---
+mode: agent
+description: Add a new DataGridStyle visual property and wire it into the theme system
+---
+
+# Add a DataGridStyle Theme Property
+
+Adds a new visual property to `DataGridStyle` and wires it through all three built-in
+themes (Light, Dark, HighContrast) and the renderer that uses it.
+
+## What to ask the user before generating code
+
+1. What is the **property name**? (e.g. `FrozenColumnSeparatorColor`, `GroupHeaderFontSize`)
+2. What is its **type**? (`GridColor`, `GridFont`, `float`, `bool`, etc.)
+3. What is the **Light theme default value**?
+4. What is the **Dark theme value**?
+5. What is the **HighContrast theme value**?
+6. Which part of the renderer will **consume** this property?
+
+---
+
+## Files to modify
+
+| File | Change |
+|---|---|
+| `src/KumikoUI.Core/Models/GridState.cs` | Add property to `DataGridStyle` |
+| `src/KumikoUI.Core/Models/DataGridTheme.cs` | Set value in Dark and HighContrast themes |
+| `src/KumikoUI.Core/DataGridRenderer.cs` | Use the property in the rendering path |
+| `tests/KumikoUI.Core.Tests/DataGridThemeTests.cs` | Add two `[Fact]` tests |
+
+---
+
+## Step 1 — `DataGridStyle` property
+
+In `src/KumikoUI.Core/Models/GridState.cs`, add the property inside `DataGridStyle`:
+
+```csharp
+/// <summary>
+/// {Description of what this property controls.}
+/// Default (Light): {lightValue}.
+/// </summary>
+public {Type} {PropertyName} { get; set; } = {lightDefault};
+```
+
+---
+
+## Step 2 — `DataGridTheme` — Dark and HighContrast
+
+In `src/KumikoUI.Core/Models/DataGridTheme.cs`:
+
+```csharp
+// Inside CreateDark():
+{PropertyName} = {darkValue},
+
+// Inside CreateHighContrast():
+{PropertyName} = {highContrastValue},
+```
+
+---
+
+## Step 3 — Renderer usage
+
+In `src/KumikoUI.Core/DataGridRenderer.cs`, use `style.{PropertyName}` where
+this visual feature is drawn. Typically inside a `Draw*` helper method or inline
+in the render loop.
+
+Example (for a color property):
+```csharp
+var separatorPaint = new GridPaint
+{
+    Color = style.{PropertyName},
+    Style = PaintStyle.Stroke,
+    StrokeWidth = 1f
+};
+ctx.DrawLine(x, top, x, bottom, separatorPaint);
+```
+
+---
+
+## Step 4 — Unit tests
+
+In `tests/KumikoUI.Core.Tests/DataGridThemeTests.cs`:
+
+```csharp
+[Fact]
+public void Dark_{PropertyName}_HasExpectedValue()
+{
+    var theme = DataGridTheme.Create(DataGridThemeMode.Dark);
+    Assert.Equal({darkValue}, theme.{PropertyName});
+}
+
+[Fact]
+public void HighContrast_{PropertyName}_HasExpectedValue()
+{
+    var theme = DataGridTheme.Create(DataGridThemeMode.HighContrast);
+    Assert.Equal({highContrastValue}, theme.{PropertyName});
+}
+```
+
+---
+
+## Rules
+
+- Property type must be from `KumikoUI.Core.Rendering` or a BCL type.
+  Valid types: `GridColor`, `GridFont`, `float`, `int`, `bool`, `string?`.
+- Never use `Microsoft.Maui.Graphics.Color` or `SkiaSharp.SKColor` in Core models.
+- Always set a non-null/non-default value in all three theme factories.
+- Default (property initializer) reflects the Light theme value.
+- Run `dotnet test tests/KumikoUI.Core.Tests/` after changes.

--- a/.github/prompts/add-unit-test.prompt.md
+++ b/.github/prompts/add-unit-test.prompt.md
@@ -1,0 +1,141 @@
+---
+mode: agent
+description: Add a unit test for a KumikoUI.Core class
+---
+
+# Add a Unit Test
+
+Add xUnit tests to `tests/KumikoUI.Core.Tests/` for a class in `KumikoUI.Core`.
+
+## Key rules (read before generating)
+
+- Test framework: **xUnit** (`[Fact]` and `[Theory]` + `[InlineData]`). Never use NUnit or MSTest.
+- One test class per source class (e.g., `GridRectTests` for `GridRect`).
+- Test file name: `{ClassName}Tests.cs` — must match the existing naming convention.
+- No SkiaSharp or MAUI dependencies — `KumikoUI.Core` only.
+- Test project targets `net9.0`.
+- Tests go in `tests/KumikoUI.Core.Tests/`.
+- Existing test files for reference: `GridRectTests.cs`, `SelectionModelTests.cs`,
+  `DataGridSourceTests.cs`, `InertialScrollerTests.cs`, `GridLayoutEngineTests.cs`.
+
+## What to ask before generating
+
+1. **Which class** should be tested? (Give full class name and namespace.)
+2. **Which method(s) or property/ies** need coverage?
+3. **Are there any edge cases** the user specifically wants covered?
+
+---
+
+## Template: `[Fact]` test
+
+```csharp
+[Fact]
+public void {MethodName}_{Scenario}_Returns{ExpectedResult}()
+{
+    // Arrange
+    var sut = new {ClassName}(/* constructor args */);
+
+    // Act
+    var result = sut.{MethodName}(/* args */);
+
+    // Assert
+    Assert.Equal(expected, result);
+}
+```
+
+## Template: `[Theory]` data-driven test
+
+```csharp
+[Theory]
+[InlineData(/* input1 */, /* expected1 */)]
+[InlineData(/* input2 */, /* expected2 */)]
+public void {MethodName}_{GeneralScenario}(/* paramType input */, /* resultType expected */)
+{
+    var sut = new {ClassName}();
+    Assert.Equal(expected, sut.{MethodName}(input));
+}
+```
+
+---
+
+## Example: `DataGridSource` sorting test
+
+```csharp
+public class DataGridSourceSortingTests
+{
+    private static DataGridSource MakeSource(IList items, List<DataGridColumn> columns)
+    {
+        var source = new DataGridSource();
+        foreach (var col in columns) source.Columns.Add(col);
+        source.ItemsSource = items;
+        return source;
+    }
+
+    [Fact]
+    public void ApplySort_Ascending_OrdersRowsCorrectly()
+    {
+        var items   = new List<Employee>
+        {
+            new Employee { Id = 3, Name = "Charlie" },
+            new Employee { Id = 1, Name = "Alice" },
+            new Employee { Id = 2, Name = "Bob" },
+        };
+        var col     = new DataGridColumn { PropertyName = "Name", ColumnType = DataGridColumnType.Text };
+        var source  = MakeSource(items, [col]);
+
+        source.ApplySort(col);   // ascending first
+
+        Assert.Equal("Alice",   source.GetCellDisplayText(0, col));
+        Assert.Equal("Bob",     source.GetCellDisplayText(1, col));
+        Assert.Equal("Charlie", source.GetCellDisplayText(2, col));
+    }
+}
+```
+
+---
+
+## `FakeDrawingContext` helper (if needed)
+
+When testing renderers, create a no-op `IDrawingContext` test double:
+
+```csharp
+// tests/KumikoUI.Core.Tests/TestHelpers/FakeDrawingContext.cs
+using KumikoUI.Core.Rendering;
+
+namespace KumikoUI.Core.Tests.TestHelpers;
+
+internal sealed class FakeDrawingContext : IDrawingContext
+{
+    public void DrawRect(GridRect r, GridPaint p) { }
+    public void FillRect(GridRect r, GridPaint p) { }
+    public void DrawRoundRect(GridRect r, float cr, GridPaint p) { }
+    public void FillRoundRect(GridRect r, float cr, GridPaint p) { }
+    public void DrawLine(float x1, float y1, float x2, float y2, GridPaint p) { }
+    public void DrawText(string t, float x, float y, GridPaint p) { }
+    public void DrawTextInRect(string t, GridRect r, GridPaint p,
+        GridTextAlignment h = GridTextAlignment.Left,
+        GridVerticalAlignment v = GridVerticalAlignment.Center,
+        bool clip = true) { }
+    public GridSize MeasureText(string t, GridPaint p) => new GridSize(t.Length * 8, 14);
+    public GridFontMetrics GetFontMetrics(GridPaint p) => new GridFontMetrics(14, 0, 2);
+    public void ClipRect(GridRect r) { }
+    public void Save() { }
+    public void Restore() { }
+    public void Translate(float dx, float dy) { }
+    public void DrawImage(object image, GridRect dest) { }
+    public void Dispose() { }
+}
+```
+
+---
+
+## Running tests
+
+```shell
+dotnet test tests/KumikoUI.Core.Tests/
+```
+
+To run a single test class:
+```shell
+dotnet test tests/KumikoUI.Core.Tests/ --filter "FullyQualifiedName~{ClassName}Tests"
+```

--- a/.github/prompts/configure-datagrid-features.prompt.md
+++ b/.github/prompts/configure-datagrid-features.prompt.md
@@ -1,0 +1,204 @@
+---
+mode: agent
+description: Set up sorting, filtering, grouping, and summaries on DataGridView
+---
+
+# Configure DataGridSource Features
+
+Adds sorting, filtering, grouping, and/or summary rows to an existing `DataGridView`
+binding. All configuration targets `DataGridSource` in `KumikoUI.Core.Models`.
+
+## What to ask before generating
+
+1. Which features are needed? (sorting / filtering / grouping / summaries / all)
+2. What are the **property names** of columns that need these features?
+3. For summaries: which aggregates are needed? (Sum, Average, Count, Min, Max, Custom)
+4. For grouping: should groups default to **expanded** or **collapsed**?
+5. Is the data source a raw `IList` or an `ObservableCollection<T>` (live updates)?
+
+---
+
+## Sorting
+
+Sorting is **automatic** — tapping a column header cycles Ascending → Descending → None.
+To enable/disable per-column:
+
+```csharp
+// XAML:
+<core:DataGridColumn AllowSorting="True" ... />
+
+// Code (default is True):
+column.AllowSorting = false;  // disable for specific column
+```
+
+**Programmatic sort:**
+```csharp
+// Single column ascending:
+dataGridView.Source.ApplySort(column, SortDirection.Ascending);
+
+// Multi-column (set SortOrder to control priority):
+columnA.SortDirection = SortDirection.Ascending;
+columnA.SortOrder     = 1;
+columnB.SortDirection = SortDirection.Descending;
+columnB.SortOrder     = 2;
+dataGridView.Source.ApplySorts();
+```
+
+---
+
+## Filtering
+
+Filtering uses `FilterDescription` with up to two `FilterCondition` objects (AND/OR).
+
+```csharp
+// Text contains filter:
+var filter = new FilterDescription(column)
+{
+    Condition1 = new FilterCondition
+    {
+        TextOperator = TextFilterOperator.Contains,
+        Value        = "Engineering"
+    }
+};
+dataGridView.Source.ApplyFilter(column, filter);
+
+// Numeric range filter (AND):
+var numFilter = new FilterDescription(numericColumn)
+{
+    Condition1 = new FilterCondition
+    {
+        NumericOperator = NumericFilterOperator.GreaterThan,
+        Value = 50000d
+    },
+    LogicalOperator = FilterLogicalOperator.And,
+    Condition2 = new FilterCondition
+    {
+        NumericOperator = NumericFilterOperator.LessThanOrEqual,
+        Value = 150000d
+    }
+};
+dataGridView.Source.ApplyFilter(numericColumn, numFilter);
+
+// Clear filter:
+dataGridView.Source.ApplyFilter(column, null);
+```
+
+**Excel-style value-checklist filter** (built into the column header popup; user-driven):
+Enabled by default when `AllowFiltering="True"` on the column (the default).
+
+---
+
+## Grouping
+
+```csharp
+// Code — add before or after ItemsSource is set:
+dataGridView.Source.GroupDescriptions.Add(
+    new GroupDescription("Department"));
+
+// Multi-level:
+dataGridView.Source.GroupDescriptions.Add(
+    new GroupDescription("Department"));
+dataGridView.Source.GroupDescriptions.Add(
+    new GroupDescription("City"));
+
+dataGridView.Source.RebuildView();   // required after changing GroupDescriptions
+
+// Custom display text:
+dataGridView.Source.GroupDescriptions.Add(new GroupDescription("HireDate")
+{
+    DisplayTextSelector = key => key is DateTime dt ? dt.ToString("yyyy") : key?.ToString() ?? ""
+});
+```
+
+**Group summary rows (in XAML):**
+```xml
+<dg:DataGridView.GroupSummaryRows>
+    <core:GroupSummaryRow Name="GroupTotals">
+        <core:GroupSummaryRow.Columns>
+            <core:SummaryColumnDescription PropertyName="Salary"
+                                           SummaryType="Sum"
+                                           Format="C0"
+                                           Label="Group Total: " />
+        </core:GroupSummaryRow.Columns>
+    </core:GroupSummaryRow>
+</dg:DataGridView.GroupSummaryRows>
+```
+
+---
+
+## Table Summary Rows
+
+**In XAML:**
+```xml
+<dg:DataGridView.TableSummaryRows>
+
+    <core:TableSummaryRow Name="Averages" Position="Top" Title="Averages">
+        <core:TableSummaryRow.Columns>
+            <core:SummaryColumnDescription PropertyName="Salary"
+                                           SummaryType="Average"
+                                           Format="C0" />
+            <core:SummaryColumnDescription PropertyName="Performance"
+                                           SummaryType="Average"
+                                           Format="N1" />
+        </core:TableSummaryRow.Columns>
+    </core:TableSummaryRow>
+
+    <core:TableSummaryRow Name="Totals" Position="Bottom" Title="Totals">
+        <core:TableSummaryRow.Columns>
+            <core:SummaryColumnDescription PropertyName="Salary"
+                                           SummaryType="Sum"
+                                           Format="C0" />
+            <core:SummaryColumnDescription PropertyName="Id"
+                                           SummaryType="Count"
+                                           Label="Rows: " />
+        </core:TableSummaryRow.Columns>
+    </core:TableSummaryRow>
+
+</dg:DataGridView.TableSummaryRows>
+```
+
+**In code:**
+```csharp
+var summaryRow = new TableSummaryRow("Totals", SummaryPosition.Bottom)
+{
+    Title   = "Totals",
+    Columns =
+    {
+        new SummaryColumnDescription("Salary", SummaryType.Sum)   { Format = "C0" },
+        new SummaryColumnDescription("Id",     SummaryType.Count) { Label = "Rows: " },
+        new SummaryColumnDescription("Rating", SummaryType.Max)   { Label = "Best: " }
+    }
+};
+dataGridView.TableSummaryRows.Add(summaryRow);
+```
+
+**Summary types:**
+| `SummaryType` | Description |
+|---|---|
+| `Sum` | Total of all numeric values |
+| `Average` | Mean of all numeric values |
+| `Count` | Number of visible rows |
+| `Min` | Minimum value |
+| `Max` | Maximum value |
+| `Custom` | Provide `CustomAggregator = (values) => ...` |
+
+---
+
+## Live data
+
+```csharp
+// Use ObservableCollection<T> for O(1) add/remove notifications:
+Employees = new ObservableCollection<Employee>(data);
+
+// Bind:
+dataGridView.ItemsSource = Employees;
+
+// Add/remove — grid updates automatically:
+Employees.Add(new Employee { ... });
+Employees.RemoveAt(index);
+
+// For bulk changes, batch with BeginUpdate/EndUpdate:
+dataGridView.Source.BeginUpdate();
+for (var item in newItems) Employees.Add(item);
+dataGridView.Source.EndUpdate();
+```

--- a/.github/prompts/rendering-pipeline.prompt.md
+++ b/.github/prompts/rendering-pipeline.prompt.md
@@ -1,0 +1,143 @@
+---
+mode: agent
+description: Debug, optimize, or extend the KumikoUI rendering pipeline
+---
+
+# Rendering Pipeline — Debug and Extend
+
+This prompt helps with understanding, debugging, or extending the KumikoUI canvas
+rendering pipeline.
+
+---
+
+## Pipeline overview
+
+```
+DataGridView.OnPaintSurface
+  │
+  └─ DataGridRenderer.Render(IDrawingContext, DataGridSource, GridLayoutEngine, ...)
+        │
+        ├─ DrawHeaderRow(...)         — column headers, sort indicators, filter icons
+        ├─ DrawFrozenRows(...)         — frozen-top data rows
+        ├─ DrawScrollableArea(...)     — virtual row loop (only visible rows rendered)
+        │     └─ DrawDataRow(row, ...)
+        │           └─ DrawCell(cell, ICellRenderer, ...)
+        ├─ DrawFrozenColumns(...)      — left and right frozen column overlays
+        ├─ DrawGroupHeaders(...)       — expandable group header rows
+        ├─ DrawSummaryRows(...)        — table-level summary rows
+        ├─ DrawGroupSummaryRows(...)   — per-group summary rows
+        ├─ DrawActiveEditor(...)       — overlays the active DrawnComponent editor
+        ├─ DrawScrollbars(...)         — canvas-drawn scrollbars
+        └─ DrawRowDragOverlay(...)     — drag-reorder ghost row
+```
+
+All draw calls go through `IDrawingContext` → `SkiaDrawingContext` → `SKCanvas`.
+
+---
+
+## Performance checklist
+
+### Allocations in the hot path
+
+KumikoUI avoids per-frame heap allocations. When adding render code:
+
+- **Use `for` loops** over `foreach` on `List<>` (avoids enumerator boxing).
+- **Use `PopulateVisible*` methods** on `GridLayoutEngine` (write into pre-allocated `List<>`).
+- **Do NOT use LINQ** (`.Where(...)`, `.Select(...)`) inside `Render(...)` or any method
+  it calls.
+- **Do NOT `new` SkiaSharp objects** (`SKPaint`, `SKFont`, `SKPath`) inside the render loop.
+  `SkiaDrawingContext` caches them keyed by `PaintKey` / `FontKey` structs.
+
+### `PaintCache`
+
+`KumikoUI.Core.Rendering.PaintCache` pre-builds `GridPaint` instances from `DataGridStyle`
+at theme-change time. Prefer `paintCache.CellPaint(isSelected, style)` over
+constructing new `GridPaint` objects inline.
+
+---
+
+## Adding a new draw pass
+
+1. Add a private `Draw{FeatureName}(IDrawingContext ctx, ...)` method to `DataGridRenderer`.
+2. Call it from `Render(...)` at the correct z-order position (before editor overlay).
+3. Use `ctx.Save()` / `ctx.Restore()` around any `ctx.ClipRect()` or `ctx.Translate()`.
+4. Use `style.*` for all colors and sizes — never hardcode.
+
+Template:
+```csharp
+private void Draw{FeatureName}(
+    IDrawingContext ctx,
+    DataGridSource source,
+    GridLayoutEngine layout,
+    DataGridStyle style,
+    ScrollState scroll)
+{
+    ctx.Save();
+    try
+    {
+        // ... drawing using ctx.Fill/DrawRect, ctx.DrawText, etc.
+    }
+    finally
+    {
+        ctx.Restore();
+    }
+}
+```
+
+---
+
+## `SkiaDrawingContext` — when you need native Skia
+
+`SkiaDrawingContext` is in `KumikoUI.SkiaSharp`. It wraps `SKCanvas` and adds:
+
+- **Per-frame paint cache** — `GetOrCreatePaint(PaintKey key)` returns a cached `SKPaint`
+- **Per-frame font cache** — `GetOrCreateFont(FontKey key)` returns a cached `SKFont`
+- **Frame disposal** — All cached objects are `Dispose()`d when the context is disposed
+
+If you need a SkiaSharp feature not exposed by `IDrawingContext`, **add it to the
+`IDrawingContext` interface first** (in `KumikoUI.Core`), then implement it in
+`SkiaDrawingContext` (in `KumikoUI.SkiaSharp`).
+
+Never reach directly into `SkiaDrawingContext` from Core renderer code.
+
+---
+
+## Hit testing
+
+`HitTesting` (in `KumikoUI.Core.Input`) converts a pointer position to a semantic
+grid location:
+
+```csharp
+var hit = HitTesting.HitTest(
+    pointerX, pointerY,
+    layout, source, style, scroll,
+    viewportWidth, viewportHeight);
+
+switch (hit.Region)
+{
+    case HitRegion.Cell:
+        // hit.Row, hit.Column
+        break;
+    case HitRegion.Header:
+        // hit.Column
+        break;
+    case HitRegion.GroupHeader:
+        // hit.FlatRowIndex
+        break;
+    case HitRegion.ColumnResizeHandle:
+        // hit.Column
+        break;
+}
+```
+
+---
+
+## Common rendering bugs
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Frozen columns show wrong content | Scrollable x-offset applied to frozen draw pass | Ensure frozen pass does NOT offset by `scroll.HorizontalOffset` |
+| Clipping bleeds outside cell | Missing `ctx.ClipRect(cellRect)` before text draw | Wrap text draw in `Save`/`ClipRect(cellRect)`/`Restore` |
+| Editor flickers or paints behind data | `DrawActiveEditor` called before data rows | Move `DrawActiveEditor` call to after all data/group passes |
+| Selection highlight not updating | `InvalidateSurface()` not called after `SelectionModel` change | Subscribe to `SelectionModel.Changed` and call `InvalidateSurface()` |
+| Font size not scaling with device | DPI scaling not applied | Multiply `GridFont.Size` by `SKCanvasView.CanvasSize / DeviceSize` ratio |


### PR DESCRIPTION
## Summary

Adds a complete GitHub Copilot AI assistance configuration for the KumikoUI solution — scoped instruction files that activate by file context, plus reusable skill prompts for common development tasks.

---

## Files Added

### `.github/copilot-instructions.md` (index)
Lightweight entry point. Contains a linked table of all scoped instruction files and skill prompts with descriptions, so Copilot (and developers) know exactly where to look for deeper context.

### `.github/instructions/` — 6 scoped instruction files

Each file has an `applyTo` frontmatter glob so VS Code / Copilot injects only the relevant context for the files you have open:

| File | Activates for | Covers |
|---|---|---|
| `architecture.instructions.md` | `**` (always) | Project structure, 3-layer dependency rules, namespace map, C# code style |
| `rendering.instructions.md` | `Rendering/**`, `SkiaSharp/**`, `DataGridRenderer.cs` | `IDrawingContext` API, `GridPaint`/`GridColor`/`GridRect`, `ICellRenderer`, render-loop z-order, `SkiaDrawingContext` internals, `GridLayoutEngine`, performance rules |
| `components-and-editing.instructions.md` | `Components/**`, `Editing/**` | `DrawnComponent` lifecycle & signals, `CellEditorFactory` wiring, `EditorDescriptor`, `EditSession` pipeline, validation, `InertialScroller` |
| `models-and-data.instructions.md` | `Models/**` | `DataGridColumn` properties & types, `DataGridSource` (sort/filter/group/summary), `DataGridStyle` theming, `CellStyle`/`RowStyle` |
| `maui-control.instructions.md` | `Maui/**`, `samples/**` | `DataGridView` XAML, all column type examples, summary row XAML, `MauiProgram` bootstrap, platform-specific internals |
| `testing.instructions.md` | `tests/**` | xUnit-only rules, `[Fact]`/`[Theory]` templates, `FakeDrawingContext` test double |

### `.github/prompts/` — 7 skill prompts

Reusable prompts invokable via `@workspace /add-cell-renderer` etc.:

- `add-cell-renderer.prompt.md` — scaffold a new `ICellRenderer`
- `add-drawn-component.prompt.md` — scaffold a new canvas-drawn editor
- `add-column-type.prompt.md` — add a `DataGridColumnType` end-to-end (5 touch-points)
- `add-theme-property.prompt.md` — add a `DataGridStyle` property across all 3 themes
- `add-unit-test.prompt.md` — write xUnit tests for Core classes
- `configure-datagrid-features.prompt.md` — wire sorting/filtering/grouping/summaries
- `rendering-pipeline.prompt.md` — debug or extend the draw pipeline