### PR TITLE
Add per-column DataGrid edit triggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ artifacts/
 # OS generated files
 .DS_Store
 Thumbs.db
+
+*.lscache

--- a/samples/SampleApp.Maui/MvvmActionsPage.xaml
+++ b/samples/SampleApp.Maui/MvvmActionsPage.xaml
@@ -1,30 +1,67 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:dg="clr-namespace:KumikoUI.Maui;assembly=KumikoUI.Maui"
              xmlns:core="clr-namespace:KumikoUI.Core.Models;assembly=KumikoUI.Core"
              xmlns:render="clr-namespace:KumikoUI.Core.Rendering;assembly=KumikoUI.Core"
+             xmlns:editing="clr-namespace:KumikoUI.Core.Editing;assembly=KumikoUI.Core"
              x:Class="SampleApp.Maui.MvvmActionsPage"
-             Title="MVVM Row Actions">
+             Title="MVVM + Column EditTriggers">
 
-    <Grid RowDefinitions="Auto,*" Padding="0">
-        <Label Text="MVVM Row Actions — Tap Delete or Details on any row"
+    <Grid RowDefinitions="Auto,Auto,*" Padding="0">
+
+        <Label Text="Column-Level EditTriggers"
                FontSize="18"
                FontAttributes="Bold"
-               Padding="16,12"
+               Padding="16,12,16,2"
                Grid.Row="0" />
 
+        <!--  Per-column trigger legend  -->
+        <VerticalStackLayout Grid.Row="1" Padding="16,0,16,8" Spacing="2">
+            <Label FontSize="12" TextColor="Gray">
+                <Label.FormattedText>
+                    <FormattedString>
+                        <Span Text="Name " FontAttributes="Bold" />
+                        <Span Text="Single-tap, F2, or type to edit" FontAttributes="Italic" />
+                        <Span Text="   " FontAttributes="Bold" />
+                        <Span Text="Department " FontAttributes="Bold" />
+                        <Span Text="Double-tap or F2 only" FontAttributes="Italic" />
+                    </FormattedString>
+                </Label.FormattedText>
+            </Label>
+            <Label FontSize="12" TextColor="Gray">
+                <Label.FormattedText>
+                    <FormattedString>
+                        <Span Text="Level " FontAttributes="Bold" />
+                        <Span Text="Double-tap only" FontAttributes="Italic" />
+                        <Span Text="   " FontAttributes="Bold" />
+                        <Span Text="Salary " FontAttributes="Bold" />
+                        <Span Text="F2 key only (most protected)" FontAttributes="Italic" />
+                        <Span Text="   " FontAttributes="Bold" />
+                        <Span Text="Actions " FontAttributes="Bold" />
+                        <Span Text="Single-tap (column override)" FontAttributes="Italic" />
+                    </FormattedString>
+                </Label.FormattedText>
+            </Label>
+        </VerticalStackLayout>
+
         <!--
-            x:Name="actionsGrid" is referenced below by the command bindings.
-            actionsGrid.BindingContext = MvvmActionsViewModel (set in code-behind).
+            Grid-level EditTriggers = Default (DoubleTap | F2Key | Typing).
+            Each column below overrides this with its own EditTriggers value,
+            demonstrating the full range of per-column trigger configurations.
+
+            x:Name="actionsGrid" is referenced by the command bindings below.
+            BindingContext = MvvmActionsViewModel (set in code-behind).
         -->
         <dg:DataGridView x:Name="actionsGrid"
-                         Grid.Row="1"
+                         Grid.Row="2"
                          ItemsSource="{Binding Employees}"
-                         EditTriggers="SingleTap,F2Key"
+                         EditTriggers="DoubleTap, F2Key, Typing"
                          RowHeight="44"
                          HeaderHeight="40">
             <dg:DataGridView.Columns>
+
+                <!-- Id \u2014 read-only; no EditTriggers needed -->
                 <core:DataGridColumn Header="Id"
                                      PropertyName="Id"
                                      ColumnType="Numeric"
@@ -32,50 +69,72 @@
                                      IsReadOnly="True"
                                      AllowTabStop="False" />
 
+                <!--
+                    Name \u2014 single-tap, F2, OR typing starts editing.
+                    Most accessible column; overrides the grid-level Default.
+                -->
                 <core:DataGridColumn Header="Name"
                                      PropertyName="Name"
                                      Width="160"
-                                     IsReadOnly="True" />
+                                     EditTriggers="SingleTap, F2Key, Typing" />
 
+                <!--
+                    Department \u2014 double-tap or F2 only.
+                    Typing excluded to prevent accidental edits on a ComboBox.
+                -->
                 <core:DataGridColumn Header="Department"
                                      PropertyName="Department"
+                                     ColumnType="ComboBox"
                                      Width="130"
-                                     IsReadOnly="True" />
+                                     EditorItemsString="Engineering,Marketing,Finance,HR,Design,Product,Sales"
+                                     EditTriggers="DoubleTap, F2Key" />
 
+                <!--
+                    Level \u2014 double-tap ONLY; no F2, no typing.
+                    Picker columns benefit from explicit intent before opening a scroll wheel.
+                -->
                 <core:DataGridColumn Header="Level"
                                      PropertyName="Level"
+                                     ColumnType="Picker"
                                      Width="90"
-                                     IsReadOnly="True" />
+                                     EditorItemsString="Junior,Mid,Senior,Lead,Principal"
+                                     EditTriggers="DoubleTap" />
 
+                <!--
+                    Salary \u2014 F2 key ONLY.
+                    Protects financial data: pointer gestures cannot open the editor;
+                    the user must deliberately press F2 on a keyboard-attached device.
+                -->
                 <core:DataGridColumn Header="Salary"
                                      PropertyName="Salary"
                                      ColumnType="Numeric"
                                      Format="C0"
                                      Width="110"
-                                     IsReadOnly="True"
-                                     TextAlignment="Right" />
+                                     TextAlignment="Right"
+                                     EditTriggers="F2Key" />
 
+                <!--
+                    Active \u2014 Boolean; toggles on single-tap regardless of EditTriggers.
+                    No EditTriggers override needed; inherits grid default (unused for booleans).
+                -->
                 <core:DataGridColumn Header="Active"
                                      PropertyName="IsActive"
                                      ColumnType="Boolean"
                                      Width="60"
-                                     IsReadOnly="True"
                                      AllowTabStop="False" />
 
                 <!--
-                    Actions column.
+                    Actions column \u2014 Template with inline action buttons.
+                    Column-level EditTriggers="SingleTap" ensures buttons are always
+                    activatable with a single tap even though the grid default is DoubleTap.
+                    This is the primary use-case for the column-level override feature.
+
                     PropertyName="" short-circuits DataGridSource.BuildAccessor to
-                    return item => item, so both the renderer and the editor factory
-                    receive the full Employee object as their 'value' argument.
+                    return item => item, so both the renderer and editor factory
+                    receive the full Employee object as their value argument.
 
-                    CustomCellRenderer is fully declared here in XAML.
-                    MauiActionButtonDefinition is a BindableObject, so Command accepts
-                    {Binding} expressions.  MauiActionButtonDefinition is NOT in the
-                    visual tree, so BindingContext is NOT inherited automatically —
-                    use Source={x:Reference actionsGrid} to resolve the ViewModel.
-
-                    The editor factory (in code-behind) reuses this same Buttons list,
-                    so commands are already bound when a row is tapped.
+                    MauiActionButtonDefinition is NOT in the visual tree so BindingContext
+                    is not inherited \u2014 use Source={x:Reference actionsGrid} to resolve the VM.
                 -->
                 <core:DataGridColumn x:Name="actionsColumn"
                                      Header="Actions"
@@ -87,7 +146,8 @@
                                      AllowFiltering="False"
                                      AllowTabStop="False"
                                      SizeMode="Star"
-                                     StarWeight="1">
+                                     StarWeight="1"
+                                     EditTriggers="SingleTap">
                     <core:DataGridColumn.CustomCellRenderer>
                         <render:ActionButtonsCellRenderer>
                             <render:ActionButtonsCellRenderer.Buttons>
@@ -105,6 +165,7 @@
                         </render:ActionButtonsCellRenderer>
                     </core:DataGridColumn.CustomCellRenderer>
                 </core:DataGridColumn>
+
             </dg:DataGridView.Columns>
         </dg:DataGridView>
     </Grid>

--- a/src/KumikoUI.Core/Input/GridInputController.cs
+++ b/src/KumikoUI.Core/Input/GridInputController.cs
@@ -275,11 +275,17 @@ public class GridInputController
         switch (e.Key)
         {
             case GridKey.F2:
-                // F2 → begin editing the current cell
+                // F2 → begin editing the current cell (honours column- and grid-level F2Key flag)
                 if (_editSession != null && selection.CurrentCell.IsValid)
                 {
-                    TryBeginEdit(selection, dataSource, scroll, style, null);
-                    e.Handled = true;
+                    int f2Col = selection.CurrentCell.Column;
+                    var f2Column = f2Col >= 0 && f2Col < dataSource.Columns.Count
+                        ? dataSource.Columns[f2Col] : null;
+                    if ((GetEffectiveEditTriggers(f2Column) & EditTrigger.F2Key) != 0)
+                    {
+                        TryBeginEdit(selection, dataSource, scroll, style, null);
+                        e.Handled = true;
+                    }
                 }
                 break;
             case GridKey.Up:
@@ -370,14 +376,19 @@ public class GridInputController
             default:
                 // Typing trigger: printable character starts editing
                 if (_editSession != null && e.Character.HasValue && selection.CurrentCell.IsValid &&
-                    !e.HasControl && !e.HasAlt &&
-                    (_editSession.EditTriggers & EditTrigger.Typing) != 0)
+                    !e.HasControl && !e.HasAlt)
                 {
-                    char c = e.Character.Value;
-                    if (!char.IsControl(c))
+                    int typingCol = selection.CurrentCell.Column;
+                    var typingColumn = typingCol >= 0 && typingCol < dataSource.Columns.Count
+                        ? dataSource.Columns[typingCol] : null;
+                    if ((GetEffectiveEditTriggers(typingColumn) & EditTrigger.Typing) != 0)
                     {
-                        TryBeginEdit(selection, dataSource, scroll, style, c);
-                        e.Handled = true;
+                        char c = e.Character.Value;
+                        if (!char.IsControl(c))
+                        {
+                            TryBeginEdit(selection, dataSource, scroll, style, c);
+                            e.Handled = true;
+                        }
                     }
                 }
                 break;
@@ -769,7 +780,7 @@ public class GridInputController
 
                 // Double-tap edit trigger
                 if (_editSession != null && hit.Column != null &&
-                    (_editSession.EditTriggers & EditTrigger.DoubleTap) != 0)
+                    (GetEffectiveEditTriggers(hit.Column) & EditTrigger.DoubleTap) != 0)
                 {
                     // Boolean toggle on double-tap
                     if (hit.Column.ColumnType == DataGridColumnType.Boolean)
@@ -793,7 +804,7 @@ public class GridInputController
                 }
                 // Single-tap edit trigger for non-boolean cells
                 else if (_editSession != null &&
-                    (_editSession.EditTriggers & EditTrigger.SingleTap) != 0)
+                    (GetEffectiveEditTriggers(hit.Column) & EditTrigger.SingleTap) != 0)
                 {
                     TryBeginEdit(selection, dataSource, scroll, style, null, e);
                 }
@@ -875,7 +886,7 @@ public class GridInputController
         selection.CurrentCell = new CellPosition(hit.RowIndex, hit.ColumnIndex);
 
         if (_editSession != null && hit.Column != null &&
-            (_editSession.EditTriggers & EditTrigger.LongPress) != 0)
+            (GetEffectiveEditTriggers(hit.Column) & EditTrigger.LongPress) != 0)
         {
             if (hit.Column.ColumnType == DataGridColumnType.Boolean)
             {
@@ -1195,6 +1206,15 @@ public class GridInputController
     }
 
     // ── Edit helpers ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Resolves the effective <see cref="EditTrigger"/> for <paramref name="column"/>.
+    /// When the column has its own <see cref="DataGridColumn.EditTriggers"/> override it is
+    /// returned directly; otherwise the grid-level <see cref="EditSession.EditTriggers"/> is
+    /// used, falling back to <see cref="EditTrigger.Default"/> if the session is null.
+    /// </summary>
+    private EditTrigger GetEffectiveEditTriggers(DataGridColumn? column)
+        => column?.EditTriggers ?? _editSession?.EditTriggers ?? EditTrigger.Default;
 
     /// <summary>
     /// Try to begin editing the current cell.

--- a/src/KumikoUI.Core/Models/DataGridColumn.cs
+++ b/src/KumikoUI.Core/Models/DataGridColumn.cs
@@ -232,6 +232,18 @@ public class DataGridColumn
     /// </summary>
     public Rendering.ICellRenderer? CustomCellRenderer { get; set; }
 
+    // ── Per-column editing behaviour ───────────────────────────────
+
+    /// <summary>
+    /// Optional column-level edit trigger override.
+    /// When set, this column uses its own <see cref="Editing.EditTrigger"/> flags instead of
+    /// the grid-level <c>EditSession.EditTriggers</c> value.
+    /// Set to <see cref="Editing.EditTrigger.None"/> to disable all trigger-based editing for
+    /// this column without making it fully read-only via <see cref="IsReadOnly"/>.
+    /// <c>null</c> (default) means inherit from the grid-level setting.
+    /// </summary>
+    public Editing.EditTrigger? EditTriggers { get; set; }
+
     // ── Per-column styling ─────────────────────────────────────────
 
     /// <summary>

--- a/tests/KumikoUI.Core.Tests/DataGridColumnTests.cs
+++ b/tests/KumikoUI.Core.Tests/DataGridColumnTests.cs
@@ -159,5 +159,57 @@ public class DataGridColumnTests
         var items = col.EditorItems!.Cast<string>().ToList();
         Assert.Equal(3, items.Count);
     }
+
+    // ── EditTriggers ──────────────────────────────────────────────
+
+    [Fact]
+    public void EditTriggers_Default_IsNull()
+    {
+        var col = new DataGridColumn();
+        Assert.Null(col.EditTriggers);
+    }
+
+    [Fact]
+    public void EditTriggers_SetToNone_StoresNone()
+    {
+        var col = new DataGridColumn();
+        col.EditTriggers = KumikoUI.Core.Editing.EditTrigger.None;
+        Assert.Equal(KumikoUI.Core.Editing.EditTrigger.None, col.EditTriggers);
+    }
+
+    [Fact]
+    public void EditTriggers_SetToSingleTap_StoresSingleTap()
+    {
+        var col = new DataGridColumn();
+        col.EditTriggers = KumikoUI.Core.Editing.EditTrigger.SingleTap;
+        Assert.Equal(KumikoUI.Core.Editing.EditTrigger.SingleTap, col.EditTriggers);
+    }
+
+    [Fact]
+    public void EditTriggers_SetToCombinedFlags_StoresCombinedFlags()
+    {
+        var col = new DataGridColumn();
+        col.EditTriggers = KumikoUI.Core.Editing.EditTrigger.DoubleTap | KumikoUI.Core.Editing.EditTrigger.F2Key;
+        Assert.Equal(
+            KumikoUI.Core.Editing.EditTrigger.DoubleTap | KumikoUI.Core.Editing.EditTrigger.F2Key,
+            col.EditTriggers);
+    }
+
+    [Fact]
+    public void EditTriggers_SetThenClearedToNull_IsNull()
+    {
+        var col = new DataGridColumn { EditTriggers = KumikoUI.Core.Editing.EditTrigger.SingleTap };
+        col.EditTriggers = null;
+        Assert.Null(col.EditTriggers);
+    }
+
+    [Fact]
+    public void EditTriggers_TwoColumns_IndependentValues()
+    {
+        var col1 = new DataGridColumn { EditTriggers = KumikoUI.Core.Editing.EditTrigger.SingleTap };
+        var col2 = new DataGridColumn { EditTriggers = KumikoUI.Core.Editing.EditTrigger.None };
+        Assert.Equal(KumikoUI.Core.Editing.EditTrigger.SingleTap, col1.EditTriggers);
+        Assert.Equal(KumikoUI.Core.Editing.EditTrigger.None, col2.EditTriggers);
+    }
 }
 

--- a/tests/KumikoUI.Core.Tests/EditTriggerResolutionTests.cs
+++ b/tests/KumikoUI.Core.Tests/EditTriggerResolutionTests.cs
@@ -1,0 +1,143 @@
+using KumikoUI.Core.Editing;
+using KumikoUI.Core.Models;
+
+namespace KumikoUI.Core.Tests;
+
+/// <summary>
+/// Tests that verify the column-level EditTrigger resolution semantics:
+///   - null column.EditTriggers → falls back to grid-level value
+///   - non-null column.EditTriggers → fully overrides grid-level value
+///   - EditTrigger.None on a column blocks all trigger-based editing for that column
+/// The resolution logic (GetEffectiveEditTriggers) lives in GridInputController but the
+/// semantics are fully expressed through the DataGridColumn model and are validated here
+/// using a simple inline resolution helper that mirrors the production code exactly.
+/// </summary>
+public class EditTriggerResolutionTests
+{
+    // ── Mirrors the production resolution rule ──────────────────────────────
+    private static EditTrigger Resolve(DataGridColumn? column, EditTrigger gridLevel)
+        => column?.EditTriggers ?? gridLevel;
+
+    // ── Null column (no column in scope) ────────────────────────────────────
+
+    [Fact]
+    public void Resolve_NullColumn_ReturnsGridLevel()
+    {
+        var result = Resolve(null, EditTrigger.Default);
+        Assert.Equal(EditTrigger.Default, result);
+    }
+
+    [Fact]
+    public void Resolve_NullColumn_NoneGridLevel_ReturnsNone()
+    {
+        var result = Resolve(null, EditTrigger.None);
+        Assert.Equal(EditTrigger.None, result);
+    }
+
+    // ── Column with null EditTriggers (inherit) ──────────────────────────────
+
+    [Fact]
+    public void Resolve_ColumnWithNullEditTriggers_ReturnsGridLevel()
+    {
+        var col = new DataGridColumn { EditTriggers = null };
+        var result = Resolve(col, EditTrigger.Default);
+        Assert.Equal(EditTrigger.Default, result);
+    }
+
+    [Theory]
+    [InlineData(EditTrigger.None)]
+    [InlineData(EditTrigger.SingleTap)]
+    [InlineData(EditTrigger.DoubleTap)]
+    [InlineData(EditTrigger.F2Key)]
+    [InlineData(EditTrigger.Typing)]
+    [InlineData(EditTrigger.LongPress)]
+    [InlineData(EditTrigger.Default)]
+    public void Resolve_ColumnWithNullEditTriggers_InheritsAnyGridLevel(EditTrigger gridLevel)
+    {
+        var col = new DataGridColumn { EditTriggers = null };
+        Assert.Equal(gridLevel, Resolve(col, gridLevel));
+    }
+
+    // ── Column with explicit EditTriggers (override) ─────────────────────────
+
+    [Fact]
+    public void Resolve_ColumnOverrideNone_BlocksEvenWhenGridAllowsAll()
+    {
+        var col = new DataGridColumn { EditTriggers = EditTrigger.None };
+        var result = Resolve(col, EditTrigger.Default);
+        Assert.Equal(EditTrigger.None, result);
+        Assert.Equal(0, (int)result);   // no flags set
+    }
+
+    [Fact]
+    public void Resolve_ColumnOverrideSingleTap_IgnoresGridDoubleTap()
+    {
+        var col = new DataGridColumn { EditTriggers = EditTrigger.SingleTap };
+        var result = Resolve(col, EditTrigger.DoubleTap | EditTrigger.F2Key | EditTrigger.Typing);
+        Assert.Equal(EditTrigger.SingleTap, result);
+        Assert.Equal(0, (int)(result & EditTrigger.DoubleTap));
+    }
+
+    [Fact]
+    public void Resolve_ColumnOverrideF2Only_DoesNotHaveTypingFlag()
+    {
+        var col = new DataGridColumn { EditTriggers = EditTrigger.F2Key };
+        var result = Resolve(col, EditTrigger.Default);
+        Assert.True((result & EditTrigger.F2Key) != 0);
+        Assert.Equal(0, (int)(result & EditTrigger.Typing));
+        Assert.Equal(0, (int)(result & EditTrigger.DoubleTap));
+    }
+
+    [Fact]
+    public void Resolve_ColumnOverrideCombined_ReturnsCombined()
+    {
+        var col = new DataGridColumn
+        {
+            EditTriggers = EditTrigger.SingleTap | EditTrigger.F2Key
+        };
+        var result = Resolve(col, EditTrigger.DoubleTap);   // grid has DoubleTap only
+        Assert.Equal(EditTrigger.SingleTap | EditTrigger.F2Key, result);
+        Assert.Equal(0, (int)(result & EditTrigger.DoubleTap));
+    }
+
+    // ── Different columns can carry independent trigger sets ─────────────────
+
+    [Fact]
+    public void Resolve_TwoColumns_ReturnIndependentValues()
+    {
+        var salary = new DataGridColumn { EditTriggers = EditTrigger.DoubleTap };
+        var name   = new DataGridColumn { EditTriggers = EditTrigger.SingleTap | EditTrigger.F2Key };
+        var id     = new DataGridColumn { EditTriggers = EditTrigger.None };
+        var notes  = new DataGridColumn { EditTriggers = null };  // inherit
+
+        EditTrigger gridLevel = EditTrigger.Default;
+
+        Assert.Equal(EditTrigger.DoubleTap,                      Resolve(salary, gridLevel));
+        Assert.Equal(EditTrigger.SingleTap | EditTrigger.F2Key,  Resolve(name,   gridLevel));
+        Assert.Equal(EditTrigger.None,                            Resolve(id,     gridLevel));
+        Assert.Equal(EditTrigger.Default,                         Resolve(notes,  gridLevel));
+    }
+
+    // ── Flag membership helpers ──────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(EditTrigger.None,      EditTrigger.SingleTap,  false)]
+    [InlineData(EditTrigger.None,      EditTrigger.DoubleTap,  false)]
+    [InlineData(EditTrigger.None,      EditTrigger.F2Key,      false)]
+    [InlineData(EditTrigger.None,      EditTrigger.Typing,     false)]
+    [InlineData(EditTrigger.None,      EditTrigger.LongPress,  false)]
+    [InlineData(EditTrigger.SingleTap, EditTrigger.SingleTap,  true)]
+    [InlineData(EditTrigger.SingleTap, EditTrigger.DoubleTap,  false)]
+    [InlineData(EditTrigger.Default,   EditTrigger.DoubleTap,  true)]
+    [InlineData(EditTrigger.Default,   EditTrigger.F2Key,      true)]
+    [InlineData(EditTrigger.Default,   EditTrigger.Typing,     true)]
+    [InlineData(EditTrigger.Default,   EditTrigger.SingleTap,  false)]
+    [InlineData(EditTrigger.Default,   EditTrigger.LongPress,  false)]
+    public void FlagCheck_ReportsCorrectMembership(
+        EditTrigger columnTrigger, EditTrigger flag, bool expected)
+    {
+        var col = new DataGridColumn { EditTriggers = columnTrigger };
+        var effective = Resolve(col, EditTrigger.Default);
+        Assert.Equal(expected, (effective & flag) != 0);
+    }
+}


### PR DESCRIPTION
Enable granular control over how users initiate cell editing by introducing a column-level `EditTriggers` property, overriding grid defaults. Updates sample to demonstrate diverse editing behaviors.